### PR TITLE
Broadcasting services explicit params

### DIFF
--- a/agents/models.py
+++ b/agents/models.py
@@ -6,10 +6,10 @@ from typing import Any, Dict
 
 __all__ = ["Goal"]
 
-
 @dataclass
 class Goal:
     """Represents a single objective for an agent to solve."""
 
     text: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from  agents.models import Goal
 from  memory.base_memory import BaseMemory
 from  reasoners.base_reasoner import BaseReasoner
+from  reasoners.models import RuntimeContext
 from  llm.base_llm import BaseLLM
 from  reasoners.models import ReasoningResult
 from  tools.interface import ToolInterface
@@ -44,10 +45,11 @@ class StandardAgent:
         self.llm = llm
         self.tools = tools
         self.memory = memory
-        self.reasoner = reasoner
 
-        # Explicit handshake to wire services into the reasoner
-        self.reasoner.attach_services(llm=llm, tools=tools, memory=memory)
+        # Wire the services context into the reasoner
+        ctx = RuntimeContext(llm=llm, tools=tools, memory=memory)
+        self.reasoner = reasoner
+        self.reasoner.set_context(ctx)
 
         self._state: AgentState = AgentState.READY
 

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -58,9 +58,7 @@ class StandardAgent:
         """Solves a goal synchronously (library-style API)."""
         run_id = uuid4().hex
 
-        if hasattr(self.memory, "store"):
-            self.memory.store(f"goal:{run_id}", goal)
-
+        self.memory.store(f"goal:{run_id}", goal)
         self._state = AgentState.BUSY
 
         try:

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -1,16 +1,14 @@
 """
 StandardAgent
 
-Lightweight façade that wires together the core runtime services (LLM, memory,
-external tools) with a pluggable *reasoner* implementation.  The
-agent owns the services; the reasoner simply uses what the agent provides.
+Lightweight façade that wires together the core runtime services
+(LLM, memory, external tools) with a pluggable *reasoner* implementation.
 """
 from __future__ import annotations
 
 from  agents.models import Goal
 from  memory.base_memory import BaseMemory
 from  reasoners.base_reasoner import BaseReasoner
-from  reasoners.models import RuntimeContext
 from  llm.base_llm import BaseLLM
 from  reasoners.models import ReasoningResult
 from  tools.interface import ToolInterface
@@ -46,10 +44,9 @@ class StandardAgent:
         self.tools = tools
         self.memory = memory
 
-        # Wire the services context into the reasoner
-        ctx = RuntimeContext(llm=llm, tools=tools, memory=memory)
+        # Set llm, tools, and memory on the reasoner
         self.reasoner = reasoner
-        self.reasoner.set_context(ctx)
+        self.reasoner.set_services(llm=llm, tools=tools, memory=memory)
 
         self._state: AgentState = AgentState.READY
 

--- a/reasoners/base_reasoner.py
+++ b/reasoners/base_reasoner.py
@@ -1,36 +1,80 @@
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Dict
+from typing import Any, Dict
 
-from reasoners.models import ReasoningResult, RuntimeContext
-from typing import Any
-
+from llm.base_llm import BaseLLM
+from memory.base_memory import BaseMemory
+from reasoners.models import ReasoningResult
+from tools.interface import ToolInterface
 
 class BaseReasoner(ABC):
-    """Abstract contract for a reasoning loop implementation."""
+    """
+    Abstract contract for a reasoning-loop implementation.
 
-    _ctx: RuntimeContext | None = None
+    Each instance owns its own `llm`, `tools`, and `memory`.
+    You can supply them in the constructor *or* later via `set_services()`.
+    """
 
-    # -------------- runtime wiring -----------------------------------------
-    def set_context(self, ctx: RuntimeContext) -> None:
-        self._ctx = ctx
-        self._pass_context_to_components(ctx)
+    def __init__(
+        self,
+        *,
+        llm: BaseLLM | None = None,
+        tools: ToolInterface | None = None,
+        memory: BaseMemory | None = None,
+    ) -> None:
+        self._llm: BaseLLM | None = None
+        self._tools: ToolInterface | None = None
+        self._memory: BaseMemory | None = None
 
-    def _pass_context_to_components(self, ctx: RuntimeContext) -> None:
-        """Hook for subclasses to broadcast the context to their components."""
-        pass  # default: nothing to do
+        # Constructor-time injection (optional)
+        if llm or tools or memory:
+            self.set_services(llm=llm, tools=tools, memory=memory)
 
-    # -------------- convenient shorthand props -----------------------------
     @property
-    def llm(self):    return self._ctx.llm
+    def llm(self) -> BaseLLM:
+        if self._llm is None:
+            raise RuntimeError("Reasoner has no LLM wired in")
+        return self._llm
 
     @property
-    def tools(self):  return self._ctx.tools
+    def tools(self) -> ToolInterface:
+        if self._tools is None:
+            raise RuntimeError("Reasoner has no Tools interface wired in")
+        return self._tools
 
     @property
-    def memory(self): return self._ctx.memory
+    def memory(self) -> BaseMemory:
+        if self._memory is None:
+            raise RuntimeError("Reasoner has no Memory wired in")
+        return self._memory
+
+    def set_services(
+        self,
+        *,
+        llm: BaseLLM | None = None,
+        tools: ToolInterface | None = None,
+        memory: BaseMemory | None = None,
+    ) -> None:
+        """Inject (or overwrite) any combination of services."""
+        if llm is not None:
+            self._llm = llm
+        if tools is not None:
+            self._tools = tools
+        if memory is not None:
+            self._memory = memory
+
+        # Push the context to sub-components if any
+        self._pass_context_to_components()
+
+    def _pass_context_to_components(self) -> None:
+        """
+        Hook for subclasses to broadcast the services to their components.
+
+        Base implementation does nothing.
+        """
+        return
 
     @abstractmethod
     def run(self, goal: str, *, meta: Dict[str, Any] | None = None) -> ReasoningResult:
-        """The main entry point to execute the reasoning loop."""
         raise NotImplementedError

--- a/reasoners/base_reasoner.py
+++ b/reasoners/base_reasoner.py
@@ -64,9 +64,9 @@ class BaseReasoner(ABC):
             self._memory = memory
 
         # Pass services to components if any
-        self._pass_context_to_components()
+        self._pass_services_to_components()
 
-    def _pass_context_to_components(self) -> None:
+    def _pass_services_to_components(self) -> None:
         """
         Hook for subclasses to broadcast the services to their components.
 

--- a/reasoners/base_reasoner.py
+++ b/reasoners/base_reasoner.py
@@ -2,25 +2,33 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Dict
 
-from memory.base_memory import BaseMemory
-from tools.interface import ToolInterface
-from llm.base_llm import BaseLLM
-from reasoners.models import ReasoningResult
+from reasoners.models import ReasoningResult, RuntimeContext
 from typing import Any
 
 
 class BaseReasoner(ABC):
     """Abstract contract for a reasoning loop implementation."""
 
-    llm: BaseLLM
-    tools: ToolInterface
-    memory: BaseMemory
+    _ctx: RuntimeContext | None = None
 
-    def attach_services(self, *, llm: BaseLLM, tools: ToolInterface, memory: BaseMemory) -> None:
-        """Explicitly attaches shared services to the reasoner instance."""
-        self.llm = llm
-        self.tools = tools
-        self.memory = memory
+    # -------------- runtime wiring -----------------------------------------
+    def set_context(self, ctx: RuntimeContext) -> None:
+        self._ctx = ctx
+        self._pass_context_to_components(ctx)
+
+    def _pass_context_to_components(self, ctx: RuntimeContext) -> None:
+        """Hook for subclasses to broadcast the context to their components."""
+        pass  # default: nothing to do
+
+    # -------------- convenient shorthand props -----------------------------
+    @property
+    def llm(self):    return self._ctx.llm
+
+    @property
+    def tools(self):  return self._ctx.tools
+
+    @property
+    def memory(self): return self._ctx.memory
 
     @abstractmethod
     def run(self, goal: str, *, meta: Dict[str, Any] | None = None) -> ReasoningResult:

--- a/reasoners/base_reasoner.py
+++ b/reasoners/base_reasoner.py
@@ -27,7 +27,6 @@ class BaseReasoner(ABC):
         self._tools: ToolInterface | None = None
         self._memory: BaseMemory | None = None
 
-        # Constructor-time injection (optional)
         if llm or tools or memory:
             self.set_services(llm=llm, tools=tools, memory=memory)
 
@@ -64,7 +63,7 @@ class BaseReasoner(ABC):
         if memory is not None:
             self._memory = memory
 
-        # Push the context to sub-components if any
+        # Pass services to components if any
         self._pass_context_to_components()
 
     def _pass_context_to_components(self) -> None:

--- a/reasoners/models.py
+++ b/reasoners/models.py
@@ -1,21 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from collections import deque
 from enum import Enum, auto
 from typing import Any, Deque, List, Optional
 from pydantic import BaseModel, Field
 
-from memory.base_memory import BaseMemory
-from llm.base_llm import BaseLLM
-from tools.interface import ToolInterface
 
 __all__ = [
     "Step",
     "StepStatus",
     "ReasonerState",
     "ReasoningResult",
-    "RuntimeContext",
 ]
 
 class StepStatus(str, Enum):
@@ -64,11 +59,3 @@ class ReasoningResult(BaseModel):
     tool_calls: List[dict[str, Any]]
     success: bool
     error_message: str | None = None
-
-
-@dataclass(slots=True)
-class RuntimeContext:
-    """Shared runtime services injected once and passed everywhere."""
-    llm    : BaseLLM
-    tools  : ToolInterface
-    memory : BaseMemory

--- a/reasoners/models.py
+++ b/reasoners/models.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from collections import deque
 from enum import Enum, auto
 from typing import Any, Deque, List, Optional
-
 from pydantic import BaseModel, Field
+
+from memory.base_memory import BaseMemory
+from llm.base_llm import BaseLLM
+from tools.interface import ToolInterface
 
 __all__ = [
     "Step",
     "StepStatus",
     "ReasonerState",
     "ReasoningResult",
+    "RuntimeContext",
 ]
 
 class StepStatus(str, Enum):
@@ -59,3 +64,11 @@ class ReasoningResult(BaseModel):
     tool_calls: List[dict[str, Any]]
     success: bool
     error_message: str | None = None
+
+
+@dataclass(slots=True)
+class RuntimeContext:
+    """Shared runtime services injected once and passed everywhere."""
+    llm    : BaseLLM
+    tools  : ToolInterface
+    memory : BaseMemory

--- a/reasoners/sequential/interface.py
+++ b/reasoners/sequential/interface.py
@@ -3,23 +3,24 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Deque, Dict
 
-from memory.base_memory import BaseMemory
-from tools.interface import ToolInterface
-from llm.base_llm import BaseLLM
+from reasoners.models import RuntimeContext
 from reasoners.models import ReasonerState, Step
 
 
 class BaseComponent(ABC):
-    """Super-small DI hook shared by all components."""
+    """All components keep a reference to the shared RuntimeContext."""
+    _ctx: RuntimeContext | None = None
 
-    llm: BaseLLM | None = None
-    tools: ToolInterface | None = None
-    memory: BaseMemory | None = None
+    def set_context(self, ctx: RuntimeContext) -> None:
+        self._ctx = ctx
 
-    def attach_services(
-        self, *, llm: BaseLLM, tools: ToolInterface, memory: BaseMemory
-    ) -> None:
-        self.llm, self.tools, self.memory = llm, tools, memory
+    # convenience shorthands
+    @property
+    def llm(self):    return self._ctx.llm
+    @property
+    def tools(self):  return self._ctx.tools
+    @property
+    def memory(self): return self._ctx.memory
 
 
 class Planner(BaseComponent):

--- a/reasoners/sequential/planners/bullet_list_planner.py
+++ b/reasoners/sequential/planners/bullet_list_planner.py
@@ -107,8 +107,8 @@ class BulletListPlanner(Planner):
     def plan(self, goal: str) -> Deque[Step]:
         """Generate and validate a plan, with retries on failure."""
         if not self.llm:
-            logger.error(f"{__name__}: LLM not attached. Call attach_services first.")
-            raise RuntimeError(f"{__name__}: LLM not attached. Call attach_services first.")
+            logger.error(f"{__name__}: LLM not attached")
+            raise RuntimeError(f"{__name__}: LLM not attached")
         prompt = PLAN_GENERATION_PROMPT.format(goal=goal)
         messages = [{"role": "user", "content": prompt}]
 

--- a/reasoners/sequential/planners/bullet_list_planner.py
+++ b/reasoners/sequential/planners/bullet_list_planner.py
@@ -101,6 +101,7 @@ class BulletListPlanner(Planner):
     """An LLM-based planner that generates a markdown bullet list."""
 
     def __init__(self, max_retries: int = 1):
+        super().__init__()
         self.max_retries = max_retries
 
     def plan(self, goal: str) -> Deque[Step]:

--- a/reasoners/sequential/reasoner.py
+++ b/reasoners/sequential/reasoner.py
@@ -32,10 +32,10 @@ class SequentialReasoner(BaseReasoner):
         self.answer_builder = answer_builder
 
         # Pass services to individual components
-        self._pass_context_to_components()
+        self._pass_services_to_components()
 
     # ---------- Broadcasting context to components --------------
-    def _pass_context_to_components(self) -> None:
+    def _pass_services_to_components(self) -> None:
 
         if self._llm is None and self._tools is None and self._memory is None:
             # not wired yet – nothing to broadcast
@@ -57,7 +57,6 @@ class SequentialReasoner(BaseReasoner):
         if self.planner:
             state.plan = self.planner.plan(goal)
         else:
-
             state.plan = deque([Step(text=goal)])
 
         if not state.plan:

--- a/reasoners/sequential/reasoner.py
+++ b/reasoners/sequential/reasoner.py
@@ -32,7 +32,7 @@ class SequentialReasoner(BaseReasoner):
 
 
         # BaseReasoner will wire up the services
-        # (broadcast them to the above components by calling _pass_services_to_components).
+        # (broadcast them to the components by calling _pass_services_to_components in BaseReasoner __init__).
         super().__init__(llm=llm, tools=tools, memory=memory)
 
     # ---------- Broadcasting context to components --------------

--- a/reasoners/sequential/reasoner.py
+++ b/reasoners/sequential/reasoner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from reasoners.base_reasoner import BaseReasoner
-from reasoners.models import ReasoningResult, ReasonerState, Step
+from reasoners.models import ReasoningResult, ReasonerState, Step, RuntimeContext
 from reasoners.sequential.interface import Planner, Reflector, StepExecutor, AnswerBuilder
 from collections import deque
 
@@ -24,13 +24,11 @@ class SequentialReasoner(BaseReasoner):
         self.reflector = reflector
         self.answer_builder = answer_builder
 
-    # ---------- DI broadcast ------------------------------------
-    def attach_services(self, *, llm, tools, memory):
-        super().attach_services(llm=llm, tools=tools, memory=memory)
-
+    # ---------- Broadcasting context to components --------------
+    def _pass_context_to_components(self, ctx: RuntimeContext) -> None:
         for comp in (self.planner, self.step_executor, self.reflector, self.answer_builder):
             if comp is not None:
-                comp.attach_services(llm=llm, tools=tools, memory=memory)
+                comp.set_context(ctx)
 
     # ---------- main loop ---------------------------------------
     def run(self, goal: str, *, meta: Dict[str, Any] | None = None) -> ReasoningResult:

--- a/reasoners/sequential/reasoner.py
+++ b/reasoners/sequential/reasoner.py
@@ -25,14 +25,15 @@ class SequentialReasoner(BaseReasoner):
         reflector: Reflector | None = None,
         answer_builder: AnswerBuilder
     ):
-        super().__init__(llm=llm, tools=tools, memory=memory)
         self.planner = planner
         self.step_executor = step_executor
         self.reflector = reflector
         self.answer_builder = answer_builder
 
-        # Pass services to individual components
-        self._pass_services_to_components()
+
+        # BaseReasoner will wire up the services
+        # (broadcast them to the above components by calling _pass_services_to_components).
+        super().__init__(llm=llm, tools=tools, memory=memory)
 
     # ---------- Broadcasting context to components --------------
     def _pass_services_to_components(self) -> None:

--- a/reasoners/sequential/reflectors/rewoo_reflector.py
+++ b/reasoners/sequential/reflectors/rewoo_reflector.py
@@ -127,7 +127,7 @@ class ReWOOReflector(Reflector):
             error.__class__.__name__,
             step.text,
         )
-        if not (self.llm and self.tools and self.memory):
+        if any(s is None for s in (self._llm, self._tools, self._memory)):
             raise RuntimeError(f"{__name__}: Services llm, tools, and memory not attached")
 
         step.status, step.error = StepStatus.FAILED, str(error)

--- a/reasoners/sequential/reflectors/rewoo_reflector.py
+++ b/reasoners/sequential/reflectors/rewoo_reflector.py
@@ -109,6 +109,7 @@ class ReWOOReflector(Reflector):
     """Retry-oriented reflection for ReWOO executors."""
 
     def __init__(self, *, max_retries: int = 2):
+        super().__init__()
         self.max_retries = max_retries
         logger.info("phase=REWOO_REFLECTOR_INITIALIZED max_retries=%d", self.max_retries)
 

--- a/reasoners/sequential/reflectors/rewoo_reflector.py
+++ b/reasoners/sequential/reflectors/rewoo_reflector.py
@@ -128,7 +128,7 @@ class ReWOOReflector(Reflector):
             step.text,
         )
         if not (self.llm and self.tools and self.memory):
-            raise RuntimeError("attach_services() not called on Reflector")
+            raise RuntimeError(f"{__name__}: Services llm, tools, and memory not attached")
 
         step.status, step.error = StepStatus.FAILED, str(error)
 

--- a/reasoners/sequential/step_executors/rewoo_step_executor.py
+++ b/reasoners/sequential/step_executors/rewoo_step_executor.py
@@ -138,7 +138,7 @@ class ReWOOStepExecutor(StepExecutor):
     # ---------- public --------------------------------------------------
     def execute(self, step: Step, state: ReasonerState) -> Dict[str, Any] | None:
         if not (self.llm and self.tools and self.memory):
-            raise RuntimeError("Services not attached; call attach_services()")
+            raise RuntimeError(f"{__name__}: Services llm, tools, and memory not attached")
         logger.info(f"phase=EXECUTE_STEP step_text='{step.text}'")
         step.status = StepStatus.RUNNING
         inputs = self._fetch_inputs(step)

--- a/reasoners/sequential/step_executors/rewoo_step_executor.py
+++ b/reasoners/sequential/step_executors/rewoo_step_executor.py
@@ -131,6 +131,7 @@ class ReWOOStepExecutor(StepExecutor):
     """Executes ReWOO steps (plan-first + reflection)."""
 
     def __init__(self) -> None:
+        super().__init__()
         self._tool_cache: Dict[str, Tool] = {}
         logger.info("phase=REWOO_STEP_EXECUTOR_INITIALIZED")
 

--- a/reasoners/sequential/step_executors/rewoo_step_executor.py
+++ b/reasoners/sequential/step_executors/rewoo_step_executor.py
@@ -149,7 +149,7 @@ class ReWOOStepExecutor(StepExecutor):
             self._do_reasoning(step, inputs, state)
         else:
             self._do_tool(step, inputs, state)
-        logger.info(f"phase=EXECUTE_STEP_COMPLETE result='{step.result}'")
+        logger.info(f"phase=EXECUTE_STEP_COMPLETE")
 
     # ---------- step kinds ---------------------------------------------
     def _do_reasoning(
@@ -166,7 +166,7 @@ class ReWOOStepExecutor(StepExecutor):
             step.result = reply
             step.status = StepStatus.DONE
             self._store_output(step, state)
-            logger.info("phase=REASONING_STEP_SUCCESS")
+            logger.info(f"phase=REASONING_STEP_SUCCESS result='{reply}'")
         except Exception as exc:
             logger.error(f"phase=REASONING_STEP_FAILED error='{exc}'")
             raise ReasoningStepError(str(exc)) from exc

--- a/reasoners/sequential/step_executors/rewoo_step_executor.py
+++ b/reasoners/sequential/step_executors/rewoo_step_executor.py
@@ -137,7 +137,7 @@ class ReWOOStepExecutor(StepExecutor):
 
     # ---------- public --------------------------------------------------
     def execute(self, step: Step, state: ReasonerState) -> Dict[str, Any] | None:
-        if not (self.llm and self.tools and self.memory):
+        if any(s is None for s in (self._llm, self._tools, self._memory)):
             raise RuntimeError(f"{__name__}: Services llm, tools, and memory not attached")
         logger.info(f"phase=EXECUTE_STEP step_text='{step.text}'")
         step.status = StepStatus.RUNNING


### PR DESCRIPTION
Changing the attach_services() on BaseReasoner BaseComponents to a more explicit passing of services. 
This should enable creation of 
1. Agents
`# With an Agent (unchanged client code)
agent = StandardAgent(
    llm=my_llm,
    tools=my_tools,
    memory=my_memory,
    reasoner=SequentialReasoner(
        step_executor=my_executor,
        answer_builder=my_builder,
        planner=my_planner,
        reflector=my_reflector,
    ),
)
result = agent.solve(goal)`

2. Standalone reasoners
`reasoner = SequentialReasoner(
    llm=my_llm,
    tools=my_tools,
    memory=my_memory,
    step_executor=my_executor,
    answer_builder=my_builder,
)
print(reasoner.run("find nyt articles on Artificial Intelligence").final_answer)`