### PR TITLE
Moving success assignment to after final answer summarization in sequential reasoner

### DIFF
--- a/agents/reasoner/sequential/reasoner.py
+++ b/agents/reasoner/sequential/reasoner.py
@@ -105,10 +105,10 @@ class SequentialReasoner(BaseReasoner):
                 else:
                     raise
 
-        success = state.is_complete and not state.plan
-
         # Summarize the result
         final_answer = self.summarize_result(state)
+
+        success = state.is_complete and not state.plan
 
         return ReasoningResult(
             final_answer=final_answer,


### PR DESCRIPTION
Bug fix: 
What was happening ?
- The success variable was assigned the value prior to final answer summarizer component. 
- In sequential reasoner flow the final answer summarizer component sets is_complete to true.

Moving the assignment to after final_answer summarization call so success variable is computed with all necessary information.