### PR TITLE
Bugfix: REWOO Reflector Executor disconnect

### DIFF
--- a/agents/reasoner/sequential/reflectors/rewoo.py
+++ b/agents/reasoner/sequential/reflectors/rewoo.py
@@ -144,12 +144,12 @@ class ReWOOReflect(Reflect):
 
         elif action == "change_tool":
             tool_id = decision.get("tool_id")
-            self.memory[f"forced_tool:{new_step.text}"] = tool_id
-            logger.info("reflection_change_tool", step_text=new_step.text, forced_tool_id=tool_id)
+            self.memory[f"rewoo_reflector_suggested_tool:{new_step.text}"] = tool_id
+            logger.info("reflection_change_tool", step_text=new_step.text, rewoo_reflector_suggested_tool=tool_id)
 
         elif action == "retry_params":
             params = decision.get("params")
-            self.memory[f"forced_params:{new_step.text}"] = params
-            logger.info("reflection_retry_params", step_text=new_step.text, forced_params=params)
+            self.memory[f"rewoo_reflector_suggested_params:{new_step.text}"] = params
+            logger.info("reflection_retry_params", step_text=new_step.text, rewoo_reflector_suggested_params=params)
 
         state.plan.appendleft(new_step)

--- a/agents/reasoner/sequential/reflectors/rewoo.py
+++ b/agents/reasoner/sequential/reflectors/rewoo.py
@@ -176,7 +176,7 @@ class ReWOOReflect(Reflect):
             tool_type: str,
             params: dict = None
     ) -> None:
-        """Create suggestion dict, store in memory, and log the action."""
+        """Create reflector suggestion dict and store in memory"""
         suggestion = {
             "action": action,
             "tool": {"id": tool_id, "type": tool_type}

--- a/agents/tools/jentic.py
+++ b/agents/tools/jentic.py
@@ -35,7 +35,7 @@ class JenticTool(ToolBase):
 
         self.name = schema.get('summary', 'Unnamed Tool')
         self.description = schema.get('description', '') or f"{schema.get('method')} {schema.get('path')}"
-        self.type = "operation" if 'operation_uuid' in schema else "workflow"
+        self.type = "workflow" if 'workflow_uuid' in schema else "operation"
         self.api_name = schema.get('api_name', 'unknown')
         self.method = schema.get('method')  # For operations
         self.path = schema.get('path')      # For operations

--- a/agents/tools/jentic.py
+++ b/agents/tools/jentic.py
@@ -35,7 +35,11 @@ class JenticTool(ToolBase):
 
         self.name = schema.get('summary', 'Unnamed Tool')
         self.description = schema.get('description', '') or f"{schema.get('method')} {schema.get('path')}"
-        self.type = "workflow" if 'workflow_uuid' in schema else "operation"
+        # Allow explicit type override, otherwise infer from schema
+        if 'type' in schema:
+            self.type = schema['type']
+        else:
+            self.type = "operation" if 'operation_uuid' in schema else "workflow"
         self.api_name = schema.get('api_name', 'unknown')
         self.method = schema.get('method')  # For operations
         self.path = schema.get('path')      # For operations


### PR DESCRIPTION
Issue:
The recent refactoring in the code base disconnected the REWOO Reflector and Executor

The suggestions stored by the Reflector in memory for actions like change_tools and retry_params were not being checked by the REWOO executor and acted on.

Fix:
- The executor checks the memory first for suggestions from reflector before proceeding. 
- If suggestions are found they are acted on 

Note:
- The tool type information [operation/workflow] is required to interact with the Jentic SDK atm which is why it is stored in memory and passed along.
- The code change could have been much more minimal if Agent didnt have to be aware of the tool type information. Agent does not really care about the tool type, it is held onto solely for interacting with the SDK, this might be something we could reconsider to improve the SDK experience for a user who wants to use Jentic SDK.
 

