### PR TITLE
Removing unwanted hasattr(__setitem__) check on self.memory

### DIFF
--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -55,9 +55,7 @@ class StandardAgent:
         """Solves a goal synchronously (library-style API)."""
         run_id = uuid4().hex
 
-        if hasattr(self.memory, "__setitem__"):
-            self.memory[f"goal:{run_id}"] = goal
-
+        self.memory[f"goal:{run_id}"] = goal
         self._state = AgentState.BUSY
 
         try:


### PR DESCRIPTION
Removes the unnecessary hasattr(self.memory, "__setitem__") check in StandardAgent.solve().
self.memory is already typed as MutableMapping, which guarantees __setitem__.