### PR TITLE
Bug Fix: Early-stop on missing plan dependencies

### DIFF
--- a/agents/reasoner/sequential/exceptions.py
+++ b/agents/reasoner/sequential/exceptions.py
@@ -17,7 +17,14 @@ class ReasoningError(Exception):
 
 
 class MissingInputError(ReasoningError, KeyError):
-    """A required memory key is absent."""
+    """A required memory key by a step is absent.
+
+    Contains the specific missing memory key to allow upstream dependency pruning.
+    """
+
+    def __init__(self, message: str, missing_key: str | None = None):
+        super().__init__(message)
+        self.missing_key = missing_key
 
 
 class ToolSelectionError(ReasoningError):

--- a/agents/reasoner/sequential/executors/rewoo.py
+++ b/agents/reasoner/sequential/executors/rewoo.py
@@ -214,7 +214,7 @@ class ReWOOExecuteStep(ExecuteStep):
 
         except KeyError as e:
             missing_key = e.args[0]
-            raise MissingInputError(f"Required memory key '{missing_key}' not found for step: {step.text}") from e
+            raise MissingInputError(f"Required memory key '{missing_key}' not found for step: {step.text}", missing_key=missing_key) from e
 
         # Classify plan step as reasoning or tool call
         step_type_response = self.llm.prompt(

--- a/agents/reasoner/sequential/reasoner.py
+++ b/agents/reasoner/sequential/reasoner.py
@@ -105,9 +105,13 @@ class SequentialReasoner(BaseReasoner):
 
                 # If a downstream step lacks its required input, immediately terminate loop and summarize
                 if isinstance(exc, MissingInputError):
-                    state.history.append(f"Stopping: missing dependency '{getattr(exc, "missing_key", None)}' for step '{StepStatus.FAILED}'. Proceeding to final answer.")
+                    state.history.append( f"Stopping: missing dependency '{getattr(exc, "missing_key", None)}' for step '{step.text}'. Proceeding to final answer.")
                     break
 
+                # 2) Credentials missing: allow reflection for the failing step (to try alternate tools), but avoid cascading retries later
+                #    We do NOT prune here; we rely on the MissingInputError gate above to stop if no outputs are produced.
+
+                # Otherwise, allow reflection to attempt recovery
                 if self.reflect:
                     self.reflect(exc, step, state)
                 else:

--- a/agents/reasoner/sequential/reasoner.py
+++ b/agents/reasoner/sequential/reasoner.py
@@ -108,10 +108,6 @@ class SequentialReasoner(BaseReasoner):
                     state.history.append( f"Stopping: missing dependency '{getattr(exc, "missing_key", None)}' for step '{step.text}'. Proceeding to final answer.")
                     break
 
-                # 2) Credentials missing: allow reflection for the failing step (to try alternate tools), but avoid cascading retries later
-                #    We do NOT prune here; we rely on the MissingInputError gate above to stop if no outputs are produced.
-
-                # Otherwise, allow reflection to attempt recovery
                 if self.reflect:
                     self.reflect(exc, step, state)
                 else:


### PR DESCRIPTION
### Summary
Fixes a bug where downstream plan steps continue to reflect/retry even when an upstream step fails and its outputs are unavailable, causing unnecessary LLM/tool spend and noisy logs.

### The bug

When a plan like [Step 1 -> Step 2(depends on 1) -> Step 3(depends on 2)] runs and Step 1 fails:
- Step 1 reflects (as intended), but
- Step 2 and Step 3 still trigger retries/reflections due to missing inputs, compounding token/tool cost and producing confusing traces.

###  Root cause
The main loop treated most exceptions uniformly, attempting reflection and continuing the queue, even when a downstream step could not proceed because a required input was never produced.

### The fix
- Allow reflection on the failing step (e.g., Step 1) to attempt recovery.
- If any subsequent step raises a MissingInputError (required input not in memory), immediately stop the loop and go directly to final summarization.
 - No reflection, no retries, no cascading attempts on dependent steps.
 
###  Impact
- Significantly fewer LLM/tool calls in failure scenarios.
- Cleaner, more accurate execution logs.