### PR TITLE
Expose Jentic tool filtering via env var JENTIC_FILTER_BY_CREDENTIALS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ GEMINI_API_KEY="your-google-gemini-api-key-here"
 # Provides just in time tools for 1000+ APIs
 # Get your agent apikey by visiting: https://app.jentic.com
 JENTIC_AGENT_API_KEY ="your-jentic-api-key-here"
+
+# Restrict tool search to only tools already configured and authorized in Jentic app.jentic.com
+JENTIC_FILTER_BY_CREDENTIALS = True


### PR DESCRIPTION
**Summary**
- Add environment-controlled flag to restrict tool search to only configured/authorized tools.
- Default behavior remains unchanged unless explicitly enabled.

**Why**
- Avoid editing code to toggle capability-based tool filtering.
- Make it easy to run with only credential-ready tools in environments with limited secrets.