### PR TITLE
docs: add security & support community standards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+If you believe you've found an exploitable security issue in standard-agent,
+**please don't create a public issue**.
+
+## Reporting a vulnerability
+
+To report a vulnerability please send an email with the details to [compliance@jentic.com](mailto:compliance@jentic.com).
+
+We'll acknowledge receipt of your report ASAP, and set expectations on how we plan to handle it.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,40 @@
+# Support
+
+Thank you for using **standard-agent**!  
+We want to make sure you can get the help you need.
+
+---
+
+## 📚 Documentation
+
+Before opening a support request, please check our resources:
+
+- [Architecture Overview](./README.md#architecture-overview)  
+- [Quick Start](./README.md#quick-start)
+- [Usage Examples](README.md#usage-examples)
+
+---
+
+## 🛠 Getting Help
+
+If you encounter a bug, have a question, or need guidance, here’s how to proceed:
+
+1. **Search existing issues**:  
+   Check the [GitHub Issues](https://github.com/jentic/standard-agent/issues) to see if your question is already answered.
+
+2. **Ask the community**:  
+   Join our [Discord](https://discord.gg/yrxmDZWMqB) for general help, advice, or feature ideas.
+
+3. **Open a support issue**:  
+   If you’ve confirmed it’s not already answered, create a new issue:
+   - Include a clear title
+   - Describe the problem or question in detail
+   - Add steps to reproduce (if applicable)
+   - Mention your environment (OS, versions)
+
+---
+
+## ❤️ Contributing to Support
+
+If you know the answer to someone’s question, feel free to jump in and help!  
+We love seeing community members supporting each other.


### PR DESCRIPTION
The community standards are looking great on this repo already. The goal of this PR is to add additional [security](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository) and [support](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project) community standards.

<img width="929" height="759" alt="image" src="https://github.com/user-attachments/assets/46c1570d-ea81-4a60-a436-4c7d8294abba" />
