### PR TITLE
refactor: extracting prompt from conversational goal preprocessor to prompts/conversational.yaml

### DIFF
--- a/agents/goal_preprocessor/conversational.py
+++ b/agents/goal_preprocessor/conversational.py
@@ -7,7 +7,7 @@ from agents.prompts import load_prompts
 from utils.logger import get_logger
 logger = get_logger(__name__)
 
-_PROMPTS = load_prompts("goal_preprocessors/conversational", required_prompts=["resolve"])
+_PROMPTS = load_prompts("goal_preprocessors/conversational", required_prompts=["clarify_goal"])
 
 
 class ConversationalGoalPreprocessor(BaseGoalPreprocessor):
@@ -27,7 +27,7 @@ class ConversationalGoalPreprocessor(BaseGoalPreprocessor):
     def process(self, goal: str, history: Sequence[Dict[str, Any]]) -> Tuple[str, str | None]:
 
         history_str = "\n".join(f"Goal: {item['goal']}\nResult: {item['result']}" for item in history)
-        prompt = _PROMPTS["resolve"].format(history_str=history_str, goal=goal)
+        prompt = _PROMPTS["clarify_goal"].format(history_str=history_str, goal=goal)
         response = self.llm.prompt_to_json(prompt)
 
         if response.get("revised_goal"):

--- a/agents/prompts/goal_preprocessors/conversational.yaml
+++ b/agents/prompts/goal_preprocessors/conversational.yaml
@@ -1,4 +1,4 @@
-resolve: |
+clarify_goal: |
   <role>
   You are a Goal Disambiguator working within the Agent ecosystem.
   Your responsibility is to analyze a user's new goal in the context of the recent conversation history and determine whether the goal contains critical ambiguities that prevent execution.


### PR DESCRIPTION
In [PR](https://github.com/jentic/standard-agent/pull/42) with prompt refactor where all prompts used in the code are moved to agents/prompts and stored in yaml files the goal preprocessor prompt was missed. 
This is to refactor goal preprocessor component to do the same and align with the rest of the code base. 