### PR TITLE
pyproject.toml for pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
+build/
+dist/
 
 # Logs
 logs/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*.egg-info/
 
 # Logs
 logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,24 @@ build-backend = "setuptools.build_meta"
 name = "standard-agent"
 version = "0.1.0"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
+dependencies = [
+    "jentic>=0.9.1",
+    "openai>=1.0",
+    "pydantic>=2.0",
+    "python-dotenv>=1.0.0",
+    "litellm>=1.74.3",
+    "google-generativeai",
+    "structlog",
+    "pyyaml",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-mock",
+    "ruff",
+    "mypy",
+]
 
 [tool.setuptools]
 packages = ["agents", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,7 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["find:"]
+packages = ["agents", "utils"]
+
+[tool.setuptools.package-data]
+agents = ["prompts/**/*.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["agents", "utils"]
+packages = { find = { where = ["."], include = ["agents*", "utils*"] } }
 
 [tool.setuptools.package-data]
 agents = ["prompts/**/*.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,4 @@ dev = [
 ]
 
 [tool.setuptools]
-packages = ["agents", "utils"]
-
-[tool.setuptools.package-dir]
-agents = "agents"
-utils = "utils"
+packages = ["find:"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "standard-agent"
+version = "0.1.0"
+description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
+
+[tool.setuptools]
+packages = ["agents", "utils"]
+
+[tool.setuptools.package-dir]
+agents = "agents"
+utils = "utils"


### PR DESCRIPTION
 Small contribution to help other devs build agents with Standard Agent.

This PR adds a [pyproject.toml](https://github.com/jldec/jentic-standard-agent/blob/c3f3bee2de6090418cb1ce247025e6c72b3db480/pyproject.toml) to enable easier installation and use of this library e.g. as recommended [here](https://github.com/jentic-community/jentic-summer-hackathon/blob/main/tracks/track-01-standard-agent-discord/requirements.txt#L4). The library does not need to be published on pypi. The PR also fixes .gitignore to exclude build output directories.

### install (in new venv)
```sh
pip install -e </path/to/repo-clone>
```
OR  
_repo@branch = 'jldec/jentic-standard-agent.git@pyproject' - for testing with this PR only_
```sh
pip install git+https://github.com/jldec/jentic-standard-agent.git@pyproject#egg=standard-agent
```
OR add the git+.. url like the one above to your requirements.txt. 

> [!NOTE]
> While #55 remains unresolved you also need to pin the `openai` version by running
> ```sh
> pip install openai==1.99.9
> ```

### usage

```python
# Example - no additional sys.path required.

from agents.prebuilt import ReWOOAgent
```

### followup suggestion
It would be nicer to standardize on uv for package management, and [maintain dependencies](https://docs.astral.sh/uv/concepts/projects/dependencies/) in pyproject.toml. This PR duplicates the list of dependencies from requirements.txt. 

