### PR TITLE
Packaging: tidy pyproject, add wheel+setuptools, cap openai<1.100 to avoid import break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
-[build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "standard-agent"
 version = "0.1.0"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
+requires-python = ">=3.10"
+readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE", 'NOTICE']
 dependencies = [
     "jentic>=0.9.1",
-    "openai>=1.0",
+    "openai>=1.0,<1.100.0",
     "pydantic>=2.0",
     "python-dotenv>=1.0.0",
     "litellm>=1.74.3",
@@ -24,6 +24,10 @@ dev = [
     "ruff",
     "mypy",
 ]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = { find = { where = ["."], include = ["agents*", "utils*"] } }


### PR DESCRIPTION
### What
- Reordered and normalized pyproject.toml for clarity.
- Added wheel alongside setuptools in [build-system] to ensure wheels build reliably in isolated PEP 517 environments.
- Capped OpenAI to avoid 1.100.x which breaks imports via litellm:
  - openai>=1.0,<1.100.0
  
### Note
OpenAI cap: 1.100.x triggers ImportError: cannot import name 'ResponseTextConfig' downstream; see Issue #[55](https://github.com/jentic/standard-agent/issues/55).