### PR TITLE
Slack example: Conversational Standard Agent via Slack

### DIFF
--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -54,7 +54,6 @@ Add the following to your `.env` in the project root:
 
 Install core deps, then the Slack example deps:
 ```bash
-pip install -r requirements.txt
 pip install -r examples/slack/requirements.txt
 ```
 
@@ -66,7 +65,7 @@ From the project root:
 python examples/slack/slack_agent.py
 ```
 
-- Mention the bot in a channel: `@your-bot find the latest news about rust 1.80`
+- Mention the bot in a channel: `@your-bot find the latest new york times articles about OpenAI`
 - Or DM the bot directly.
 
 ## Notes

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -1,0 +1,78 @@
+# Slack Bot Example — Standard Agent
+
+This example lets you converse with a Standard Agent from Slack using Socket Mode.
+
+## Prerequisites
+
+- A Slack workspace where you can install custom apps
+- Python environment with project dependencies installed
+- .env configured with an LLM provider key and (optionally) tool provider key
+
+## Create a Slack App
+
+1. Create the app
+   - Open `https://api.slack.com/apps` → Create New App → From scratch → name your app and pick your workspace.
+
+2. Enable Socket Mode and get the App Token
+   - Left sidebar → Features → Socket Mode → toggle On.
+   - Click “Generate App-Level Token”, add scope `connections:write`, create it, and copy the token (starts with `xapp-`).
+   - Save it as `SLACK_APP_TOKEN` in your `.env`.
+
+3. Add bot scopes and install the app
+   - Left sidebar → Features → OAuth & Permissions → Scopes → Bot Token Scopes: add
+     - `app_mentions:read`
+     - `im:history`
+     - `chat:write`
+   - Click “Install to Workspace” (or “Reinstall to Workspace”).
+   - Copy the “Bot User OAuth Token” (starts with `xoxb-`) and save it as `SLACK_BOT_TOKEN` in your `.env`.
+
+4. Get the Signing Secret
+   - Left sidebar → Basic Information → App Credentials → “Signing Secret” → Show and copy.
+   - Save it as `SLACK_SIGNING_SECRET` in your `.env` (recommended even in Socket Mode).
+
+5. Subscribe to events (for messages)
+   - Left sidebar → Features → Event Subscriptions → toggle On.
+   - Under “Subscribe to bot events”, add:
+     - `app_mention` (channel mentions)
+     - `message.im` (direct messages)
+   - Save changes. With Socket Mode enabled, no public URL is required.
+
+6. Invite and test
+   - In Slack, invite your bot to a channel: `/invite @your-bot`.
+   - Mention the bot or DM it to start chatting.
+
+## Environment Variables
+
+Add the following to your `.env` in the project root:
+
+- `SLACK_APP_TOKEN` — App-level token with `connections:write` (Socket Mode)
+- `SLACK_BOT_TOKEN` — Bot token for posting messages
+- `SLACK_SIGNING_SECRET` — Signing secret (not strictly required for Socket Mode, but recommended)
+
+
+## Install Dependencies
+
+Install core deps, then the Slack example deps:
+```bash
+pip install -r requirements.txt
+pip install -r examples/slack/requirements.txt
+```
+
+## Run
+
+From the project root:
+
+```bash
+python examples/slack/slack_agent.py
+```
+
+- Mention the bot in a channel: `@your-bot find the latest news about rust 1.80`
+- Or DM the bot directly.
+
+## Notes
+
+- The agent composes LLM + Tools + Memory + Reasoner (ReWOO by default). Switch to ReACT via `AGENT_PROFILE=react`.
+- For tool usage, configure credentials for the tools you intend to use; default provider is the Jentic catalog when `JENTIC_AGENT_API_KEY` is present.
+- Messages are answered synchronously; long-running tool calls will block until completion.
+
+

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -76,11 +76,6 @@ From the project root:
 python examples/slack/slack_agent.py
 ```
 
-- Configure: `/standard-agent configure` (paste Jentic Agent API Key)
-- Switch profile: `/standard-agent reasoner-profile <react|rewoo>`
-- Mention-based: `@your-bot find the latest news about AI`
-- DM-based: send a goal as a direct message to the bot
-
 ### Quick flow
 
 1. Create a Slack channel.

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -20,9 +20,10 @@ This example lets you converse with a Standard Agent from Slack using Socket Mod
 
 3. Add bot scopes and install the app
    - Left sidebar → Features → OAuth & Permissions → Scopes → Bot Token Scopes: add
+     - `commands` (for slash commands)
+     - `chat:write`
      - `app_mentions:read`
      - `im:history`
-     - `chat:write`
    - Click “Install to Workspace” (or “Reinstall to Workspace”).
    - Copy the “Bot User OAuth Token” (starts with `xoxb-`) and save it as `SLACK_BOT_TOKEN` in your `.env`.
 
@@ -37,9 +38,19 @@ This example lets you converse with a Standard Agent from Slack using Socket Mod
      - `message.im` (direct messages)
    - Save changes. With Socket Mode enabled, no public URL is required.
 
-6. Invite and test
+6. Create slash command and enable interactivity
+   - Left sidebar → Features → Slash Commands → Create New Command.
+   - Command: `/standard-agent`
+   - Request URL: (leave blank for Socket Mode)
+   - Save.
+   - Left sidebar → Interactivity & Shortcuts → toggle On (no URL needed for Socket Mode).
+
+7. Invite and test
    - In Slack, invite your bot to a channel: `/invite @your-bot`.
-   - Mention the bot or DM it to start chatting.
+   - Configure the agent key via slash command: `/standard-agent configure` (a modal opens).
+   - Optionally pick a reasoner profile: `/standard-agent reasoner-profile react` or `rewoo`.
+   - Mention the bot in a channel: `@your-bot find articles about AI` (the bot replies in a thread).
+   - Or DM the bot directly and type your goal.
 
 ## Environment Variables
 
@@ -65,12 +76,22 @@ From the project root:
 python examples/slack/slack_agent.py
 ```
 
-- Mention the bot in a channel: `@your-bot find the latest new york times articles about OpenAI`
-- Or DM the bot directly.
+- Configure: `/standard-agent configure` (paste Jentic Agent API Key)
+- Switch profile: `/standard-agent reasoner-profile <react|rewoo>`
+- Mention-based: `@your-bot find the latest news about AI`
+- DM-based: send a goal as a direct message to the bot
+
+### Quick flow
+
+1. Create a Slack channel.
+2. Invite the bot: `/invite @your-bot`.
+3. If no JENTIC_AGENT_API_KEY key in `.env`, run `/standard-agent configure` and paste your Agent API Key which you can get from app.jentic.com.
+4. (Optional) Set profile: `/standard-agent reasoner-profile <react|rewoo>`. default is `rewoo`.
+5. Talk to the agent with `@your-bot <goal>` or DM the bot.
 
 ## Notes
 
-- The agent composes LLM + Tools + Memory + Reasoner (ReWOO by default). Switch to ReACT via `AGENT_PROFILE=react`.
+- The agent composes LLM + Tools + Memory + Reasoner. Choose the profile via `/standard-agent reasoner-profile <react|rewoo>`.
 - For tool usage, configure credentials for the tools you intend to use; default provider is the Jentic catalog when `JENTIC_AGENT_API_KEY` is present.
 - Messages are answered synchronously; long-running tool calls will block until completion.
 

--- a/examples/slack/README.md
+++ b/examples/slack/README.md
@@ -2,11 +2,27 @@
 
 This example lets you converse with a Standard Agent from Slack using Socket Mode.
 
-## Prerequisites
+## Quick Start
 
-- A Slack workspace where you can install custom apps
-- Python environment with project dependencies installed
-- .env configured with an LLM provider key and (optionally) tool provider key
+From the project root:
+
+```bash
+pip install -r examples/slack/requirements.txt
+python examples/slack/slack_agent.py
+```
+
+In Slack:
+- Make sure the app is installed to your workspace (App settings → OAuth & Permissions → Install to Workspace)
+- Invite the bot: `/invite @your-bot`
+- Configure the agent key: `/standard-agent configure` (paste API key from app.jentic.com)
+- Talk to the agent: `@your-bot <goal>` or DM the bot
+
+### Slash commands
+
+- `/standard-agent configure` — open a modal to paste your Jentic Agent API Key
+- `/standard-agent reasoner <react|rewoo>` — switch reasoning strategy (default: rewoo)
+- `/standard-agent reasoner list` — show available strategies and the current one
+- `/standard-agent kill` — clear the API key and reset the agent
 
 ## Create a Slack App
 
@@ -45,12 +61,6 @@ This example lets you converse with a Standard Agent from Slack using Socket Mod
    - Save.
    - Left sidebar → Interactivity & Shortcuts → toggle On (no URL needed for Socket Mode).
 
-7. Invite and test
-   - In Slack, invite your bot to a channel: `/invite @your-bot`.
-   - Configure the agent key via slash command: `/standard-agent configure` (a modal opens).
-   - Optionally pick a reasoner profile: `/standard-agent reasoner-profile react` or `rewoo`.
-   - Mention the bot in a channel: `@your-bot find articles about AI` (the bot replies in a thread).
-   - Or DM the bot directly and type your goal.
 
 ## Environment Variables
 
@@ -59,35 +69,3 @@ Add the following to your `.env` in the project root:
 - `SLACK_APP_TOKEN` — App-level token with `connections:write` (Socket Mode)
 - `SLACK_BOT_TOKEN` — Bot token for posting messages
 - `SLACK_SIGNING_SECRET` — Signing secret (not strictly required for Socket Mode, but recommended)
-
-
-## Install Dependencies
-
-Install core deps, then the Slack example deps:
-```bash
-pip install -r examples/slack/requirements.txt
-```
-
-## Run
-
-From the project root:
-
-```bash
-python examples/slack/slack_agent.py
-```
-
-### Quick flow
-
-1. Create a Slack channel.
-2. Invite the bot: `/invite @your-bot`.
-3. If no JENTIC_AGENT_API_KEY key in `.env`, run `/standard-agent configure` and paste your Agent API Key which you can get from app.jentic.com.
-4. (Optional) Set profile: `/standard-agent reasoner-profile <react|rewoo>`. default is `rewoo`.
-5. Talk to the agent with `@your-bot <goal>` or DM the bot.
-
-## Notes
-
-- The agent composes LLM + Tools + Memory + Reasoner. Choose the profile via `/standard-agent reasoner-profile <react|rewoo>`.
-- For tool usage, configure credentials for the tools you intend to use; default provider is the Jentic catalog when `JENTIC_AGENT_API_KEY` is present.
-- Messages are answered synchronously; long-running tool calls will block until completion.
-
-

--- a/examples/slack/requirements.txt
+++ b/examples/slack/requirements.txt
@@ -1,0 +1,2 @@
+slack-bolt>=1.19.0
+slack-sdk>=3.27.0

--- a/examples/slack/slack_agent.py
+++ b/examples/slack/slack_agent.py
@@ -134,7 +134,18 @@ def configure_slack_handlers(app: App, runtime: SlackAgentRuntime) -> None:
                 respond(response_type="ephemeral", text=f"Failed to open config modal: {exc}")
             return
 
-        respond(response_type="ephemeral", text="Usage: /standard-agent configure | /standard-agent reasoner <react|rewoo|list>")
+        # Kill the agent and clear the API key
+        if text == "kill":
+            runtime.current_agent = None
+            os.environ.pop("JENTIC_AGENT_API_KEY", None)
+            logger.warning("agent_killed")
+            respond(
+                response_type="ephemeral",
+                text="Agent killed. API key cleared; new requests will be rejected until reconfigured.",
+            )
+            return
+
+        respond(response_type="ephemeral", text="Usage: /standard-agent configure | /standard-agent reasoner <react|rewoo|list> | /standard-agent kill")
 
     @app.view("configure_agent_view")
     def handle_config_submit(ack, body, client):  # type: ignore[no-redef]

--- a/examples/slack/slack_agent.py
+++ b/examples/slack/slack_agent.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Optional
+
+from dotenv import load_dotenv
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+from agents.prebuilt import ReWOOAgent, ReACTAgent
+from utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def build_agent() -> ReWOOAgent | ReACTAgent:
+    profile = (os.getenv("AGENT_PROFILE") or "rewoo").strip().lower()
+    model = os.getenv("LLM_MODEL")
+    if profile == "react":
+        logger.info("initializing_react_agent", model=model)
+        return ReACTAgent(model=model)
+    logger.info("initializing_rewoo_agent", model=model)
+    return ReWOOAgent(model=model)
+
+
+def extract_goal_from_text(text: str, bot_user_id: Optional[str]) -> str:
+    if not text:
+        return ""
+    cleaned = text
+    if bot_user_id:
+        mention_pattern = re.compile(rf"<@{re.escape(bot_user_id)}>\s*")
+        cleaned = mention_pattern.sub("", cleaned).strip()
+    return cleaned
+
+
+def main() -> None:
+    load_dotenv()
+
+    app_token = os.getenv("SLACK_APP_TOKEN")
+    bot_token = os.getenv("SLACK_BOT_TOKEN")
+    signing_secret = os.getenv("SLACK_SIGNING_SECRET")
+
+    if not app_token or not bot_token:
+        print("Missing SLACK_APP_TOKEN or SLACK_BOT_TOKEN in environment.")
+        sys.exit(1)
+
+    agent = build_agent()
+
+    app = App(token=bot_token, signing_secret=signing_secret)
+
+    bot_user_id: Optional[str] = None
+
+    @app.event("app_mention")
+    def handle_app_mention(event, say):  # type: ignore[no-redef]
+        nonlocal bot_user_id
+        try:
+            text = event.get("text", "")
+            channel = event.get("channel")
+            thread_ts = event.get("ts")
+
+            if bot_user_id is None:
+                auth = app.client.auth_test()
+                bot_user_id = auth.get("user_id")
+
+            goal = extract_goal_from_text(text, bot_user_id)
+            if not goal:
+                say(text="Please provide a goal after mentioning me.", thread_ts=thread_ts)
+                return
+
+            logger.info("slack_goal_received", channel=channel, goal_preview=goal[:120])
+            result = agent.solve(goal)
+            answer = result.final_answer or "(No answer)"
+            say(text=answer[:39000], thread_ts=thread_ts)
+        except Exception as exc:  # pragma: no cover - best-effort guard
+            logger.error("slack_app_mention_error", error=str(exc), exc_info=True)
+            say(text=f"Error: {exc}")
+
+    @app.message(re.compile(".*"))
+    def handle_dm(message, say):  # type: ignore[no-redef]
+        try:
+            channel = message.get("channel")
+            channel_is_dm = bool(channel) and str(channel).startswith("D")
+            if not channel_is_dm:
+                return
+
+            text = message.get("text", "")
+            goal = extract_goal_from_text(text, None)
+            if not goal:
+                say(text="Send me a goal to get started.")
+                return
+
+            logger.info("slack_dm_goal_received", channel=channel, goal_preview=goal[:120])
+            result = agent.solve(goal)
+            answer = result.final_answer or "(No answer)"
+            say(text=answer[:39000])
+        except Exception as exc:  # pragma: no cover - best-effort guard
+            logger.error("slack_dm_error", error=str(exc), exc_info=True)
+            say(text=f"Error: {exc}")
+
+    handler = SocketModeHandler(app, app_token)
+    logger.info("slack_socket_mode_starting")
+    handler.start()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/examples/slack/slack_agent.py
+++ b/examples/slack/slack_agent.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
+from agents.standard_agent import StandardAgent
 from agents.prebuilt import ReWOOAgent, ReACTAgent
 from utils.logger import get_logger
 
@@ -16,14 +17,35 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 
-def build_agent() -> ReWOOAgent | ReACTAgent:
-    profile = (os.getenv("AGENT_PROFILE") or "rewoo").strip().lower()
+def build_agent(jentic_key: Optional[str] = None, profile: Optional[str] = None) -> StandardAgent:
+    """Construct a single global StandardAgent, with optional Jentic key and reasoner profile."""
+    # Ensure an asyncio event loop exists in this worker thread (for Jentic SDK)
+    import asyncio
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    chosen_profile = (profile or "rewoo").strip().lower()
     model = os.getenv("LLM_MODEL")
-    if profile == "react":
-        logger.info("initializing_react_agent", model=model)
-        return ReACTAgent(model=model)
-    logger.info("initializing_rewoo_agent", model=model)
-    return ReWOOAgent(model=model)
+
+    # Temporarily override env key during construction if provided
+    prev = os.environ.get("JENTIC_AGENT_API_KEY")
+    try:
+        if jentic_key is not None:
+            os.environ["JENTIC_AGENT_API_KEY"] = jentic_key
+
+        if chosen_profile == "react":
+            logger.info("initializing_react_agent", model=model)
+            return ReACTAgent(model=model)
+        logger.info("initializing_rewoo_agent", model=model)
+        return ReWOOAgent(model=model)
+    finally:
+        if prev is None:
+            os.environ.pop("JENTIC_AGENT_API_KEY", None)
+        else:
+            os.environ["JENTIC_AGENT_API_KEY"] = prev
 
 
 def extract_goal_from_text(text: str, bot_user_id: Optional[str]) -> str:
@@ -47,11 +69,100 @@ def main() -> None:
         print("Missing SLACK_APP_TOKEN or SLACK_BOT_TOKEN in environment.")
         sys.exit(1)
 
-    agent = build_agent()
+    # Single global agent, configured from env or via /standard-agent configure
+    import json
+    env_has_key = bool(os.getenv("JENTIC_AGENT_API_KEY"))
+    configured_key: Optional[str] = None
+    chosen_profile: str = "rewoo"
+    current_agent: Optional[StandardAgent] = build_agent(None, chosen_profile) if env_has_key else None
 
     app = App(token=bot_token, signing_secret=signing_secret)
 
     bot_user_id: Optional[str] = None
+
+    @app.command("/standard-agent")
+    def on_cmd_standard_agent(ack, body, client, respond):  # type: ignore[no-redef]
+        ack()
+        text = (body.get("text") or "").strip()
+
+        # Change reasoner profile: /standard-agent reasoner-profile <react|rewoo>
+        if text.startswith("reasoner-profile"):
+            parts = text.split()
+            if len(parts) != 2 or parts[1].lower() not in {"react", "rewoo"}:
+                respond(response_type="ephemeral", text="Usage: /standard-agent reasoner-profile <react|rewoo>")
+                return
+            nonlocal chosen_profile, current_agent
+            chosen_profile = parts[1].lower()
+            # Rebuild agent if we already have credentials
+            try:
+                if configured_key is not None or env_has_key:
+                    current_agent = build_agent(configured_key, chosen_profile)
+                    respond(response_type="ephemeral", text=f"Reasoner profile set to {chosen_profile} and agent reloaded.")
+                else:
+                    respond(response_type="ephemeral", text=f"Reasoner profile set to {chosen_profile}. Configure key via /standard-agent configure before use.")
+            except Exception as exc:  # pragma: no cover
+                respond(response_type="ephemeral", text=f"Failed to switch profile: {exc}")
+            return
+
+        if text == "configure":
+            try:
+                client.views_open(
+                    trigger_id=body["trigger_id"],
+                    view={
+                        "type": "modal",
+                        "callback_id": "configure_agent_view",
+                        "private_metadata": json.dumps({}),
+                        "title": {"type": "plain_text", "text": "Configure Agent"},
+                        "submit": {"type": "plain_text", "text": "Save"},
+                        "close": {"type": "plain_text", "text": "Cancel"},
+                        "blocks": [
+                            {
+                                "type": "input",
+                                "block_id": "keyb",
+                                "label": {"type": "plain_text", "text": "Agent API Key"},
+                                "element": {
+                                    "type": "plain_text_input",
+                                    "action_id": "key",
+                                    "placeholder": {"type": "plain_text", "text": "Paste key from app.jentic.com"},
+                                },
+                            }
+                        ],
+                    },
+                )
+            except Exception as exc:  # pragma: no cover
+                logger.error("open_config_modal_failed", error=str(exc), exc_info=True)
+                respond(response_type="ephemeral", text=f"Failed to open config modal: {exc}")
+            return
+
+        respond(response_type="ephemeral", text="Usage: /standard-agent configure")
+
+    @app.view("configure_agent_view")
+    def on_config_submit(ack, body, client):  # type: ignore[no-redef]
+        ack()
+        try:
+            user_id = body.get("user", {}).get("id")
+
+            key = body["view"]["state"]["values"]["keyb"]["key"]["value"].strip()
+            if not key:
+                if user_id:
+                    client.chat_postMessage(channel=user_id, text="No key provided.")
+                return
+
+            nonlocal configured_key, current_agent
+            configured_key = key
+            # Build/replace the single agent now to validate
+            try:
+                current_agent = build_agent(configured_key, chosen_profile)
+            except Exception as exc:  # pragma: no cover
+                logger.error("agent_build_failed", error=str(exc), exc_info=True)
+                if user_id:
+                    client.chat_postMessage(channel=user_id, text=f"Saved key, but failed to initialize agent: {exc}")
+                return
+
+            if user_id:
+                client.chat_postMessage(channel=user_id, text="Agent configured.")
+        except Exception as exc:  # pragma: no cover
+            logger.error("config_submit_error", error=str(exc), exc_info=True)
 
     @app.event("app_mention")
     def handle_app_mention(event, say):  # type: ignore[no-redef]
@@ -60,6 +171,7 @@ def main() -> None:
             text = event.get("text", "")
             channel = event.get("channel")
             thread_ts = event.get("ts")
+            # team_id not needed for single-agent mode
 
             if bot_user_id is None:
                 auth = app.client.auth_test()
@@ -70,35 +182,51 @@ def main() -> None:
                 say(text="Please provide a goal after mentioning me.", thread_ts=thread_ts)
                 return
 
+            # Ensure a single agent exists
+            nonlocal current_agent
+            if current_agent is None:
+                if configured_key is None and not env_has_key:
+                    say(text="Not configured. Run /standard-agent configure to set the Agent API Key.", thread_ts=thread_ts)
+                    return
+                current_agent = build_agent(configured_key, chosen_profile)
+
             logger.info("slack_goal_received", channel=channel, goal_preview=goal[:120])
-            result = agent.solve(goal)
+            result = current_agent.solve(goal)
             answer = result.final_answer or "(No answer)"
             say(text=answer[:39000], thread_ts=thread_ts)
         except Exception as exc:  # pragma: no cover - best-effort guard
             logger.error("slack_app_mention_error", error=str(exc), exc_info=True)
             say(text=f"Error: {exc}")
 
-    @app.message(re.compile(".*"))
-    def handle_dm(message, say):  # type: ignore[no-redef]
-        try:
-            channel = message.get("channel")
-            channel_is_dm = bool(channel) and str(channel).startswith("D")
-            if not channel_is_dm:
-                return
-
-            text = message.get("text", "")
-            goal = extract_goal_from_text(text, None)
-            if not goal:
-                say(text="Send me a goal to get started.")
-                return
-
-            logger.info("slack_dm_goal_received", channel=channel, goal_preview=goal[:120])
-            result = agent.solve(goal)
-            answer = result.final_answer or "(No answer)"
-            say(text=answer[:39000])
-        except Exception as exc:  # pragma: no cover - best-effort guard
-            logger.error("slack_dm_error", error=str(exc), exc_info=True)
-            say(text=f"Error: {exc}")
+    # @app.message(re.compile(".*"))
+    # def handle_dm(message, say):  # type: ignore[no-redef]
+    #     try:
+    #         channel = message.get("channel")
+    #         channel_is_dm = bool(channel) and str(channel).startswith("D")
+    #         if not channel_is_dm:
+    #             return
+    #
+    #         text = message.get("text", "")
+    #         goal = extract_goal_from_text(text, None)
+    #         if not goal:
+    #             say(text="Send me a goal to get started.")
+    #             return
+    #
+    #         # Ensure a single agent exists
+    #         with agent_lock:
+    #             if current_agent is None:
+    #                 if configured_key is None and not env_has_key:
+    #                     say(text="Not configured. Run /standard-agent configure to set the Agent API Key.")
+    #                     return
+    #                 current_agent = build_agent(configured_key)
+    #
+    #         logger.info("slack_dm_goal_received", channel=channel, goal_preview=goal[:120])
+    #         result = current_agent.solve(goal)
+    #         answer = result.final_answer or "(No answer)"
+    #         say(text=answer[:39000])
+    #     except Exception as exc:  # pragma: no cover - best-effort guard
+    #         logger.error("slack_dm_error", error=str(exc), exc_info=True)
+    #         say(text=f"Error: {exc}")
 
     handler = SocketModeHandler(app, app_token)
     logger.info("slack_socket_mode_starting")


### PR DESCRIPTION
### Summary
- Adds a runnable Slack example (examples/slack/slack_agent.py) to converse with the Standard Agent via Slack.
- Single global agent; configure via slash command; @mentions reply in thread; DMs supported.
- Quick Start and one-time setup in examples/slack/README.md.

### Key Features
- Slash commands:
  - /standard-agent configure: open modal, paste Jentic Agent API Key
  - /standard-agent reasoner <react|rewoo>: switch reasoning strategy (default: rewoo)
  - /standard-agent reasoner list: show available strategies and current profile
  - /standard-agent kill: clear API key and reset agent (simple operational reset)
- @mentions in channels: @your-bot <goal> → threaded reply
- Direct messages: DM the bot with a goal
- Per-run profile selection and runtime reconfiguration without restarting