### PR TITLE
feat: Add JSON/pretty console logging

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,14 +4,13 @@
 
     "console": {
       "enabled": true,
-      "format": "%(asctime)s | %(levelname_coloured)s | %(name)s: %(message)s"
+      "renderer": "pretty"
     },
 
     "file": {
       "enabled": true,
       "level": "DEBUG",
       "path": "logs/standard_agent.log",
-      "format": "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
       "rotation": {
         "enabled": true,
         "max_bytes": 10485760,


### PR DESCRIPTION
### Summary
- Introduces console renderer selection (json or pretty) with optional env override.
- Adds a single structured final_result log from the core agent.

### What changed
- utils/logger.py
  - Console renderer selectable via config logging.console.renderer with values: json, pretty (default pretty).
  - Optional env override LOG_CONSOLE_RENDERER (json|pretty) takes precedence.
  
- agents/standard_agent.py
  - Emits one structured final_result event (info) per run:
   - fields: run_id, success, iterations, tool_calls_count, duration_ms, goal, final_answer_preview (200 chars), model.
   
- config.json
  - Uses logging.console.renderer key for console output mode.
  
### Why
- CloudWatch and similar sinks prefer line-delimited JSON; allowing console JSON makes ingestion easy in containers.
- A single core final_result log ensures consistent observability across all entry points.
