### PR TITLE
feat: version bump up to reflect the console json logging feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.0"
+version = "0.1.1"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"


### PR DESCRIPTION
Missed bumping the version in : https://github.com/jentic/standard-agent/pull/63
This is to let CI/CD deploy new version with the changes on pypi