### PR TITLE
Make memory JSON-serializable by default; simplify conversation history; remove run-id result storage

### DIFF
--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -8,7 +8,6 @@ agent owns the services; the reasoner simply uses what the agent provides.
 from __future__ import annotations
 
 from  collections.abc import MutableMapping
-from  collections import deque
 from  agents.reasoner.base import BaseReasoner, ReasoningResult
 from  agents.llm.base_llm import BaseLLM
 from  agents.tools.base import JustInTimeToolingBase
@@ -61,7 +60,8 @@ class StandardAgent:
         self.reasoner = reasoner
 
         self.goal_preprocessor = goal_preprocessor
-        self.memory.setdefault("conversation_history", deque(maxlen=conversation_history_window))
+        self.conversation_history_window = conversation_history_window
+        self.memory.setdefault("conversation_history", [])
 
         self._state: AgentState = AgentState.READY
 
@@ -77,19 +77,17 @@ class StandardAgent:
         if self.goal_preprocessor:
             revised_goal, intervention_message = self.goal_preprocessor.process(goal, self.memory.get("conversation_history"))
             if intervention_message:
-                self.memory["conversation_history"].append({ "goal": goal, "result": f"user intervention message: {intervention_message}"})
+                self._record_interaction({"goal": goal, "result": f"user intervention message: {intervention_message}"})
                 return ReasoningResult(success=False, final_answer=intervention_message)
             goal = revised_goal
 
-        self.memory[f"goal:{run_id}"] = goal
         self._state = AgentState.BUSY
 
         try:
             result = self.reasoner.run(goal)
             result.final_answer = self.llm.prompt(_PROMPTS["summarize"].format(goal=goal, history=getattr(result, "transcript", "")))
 
-            self.memory[f"result:{run_id}"] = result
-            self.memory["conversation_history"].append({"goal": goal, "result": result.final_answer})
+            self._record_interaction({"goal": goal, "result": result.final_answer})
             self._state = AgentState.READY
 
             duration_ms = int((time.perf_counter() - start_time) * 1000)
@@ -109,3 +107,10 @@ class StandardAgent:
         except Exception:
             self._state = AgentState.NEEDS_ATTENTION
             raise
+
+    def _record_interaction(self, entry: dict) -> None:
+        if self.conversation_history_window <= 0:  # disabled
+            return
+        self.memory["conversation_history"].append(entry)
+        if self.conversation_history_window and len(self.memory["conversation_history"]) > self.conversation_history_window:
+            del self.memory["conversation_history"][:-self.conversation_history_window]

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -109,8 +109,7 @@ class StandardAgent:
             raise
 
     def _record_interaction(self, entry: dict) -> None:
-        if self.conversation_history_window <= 0:  # disabled
+        if self.conversation_history_window <= 0:
             return
         self.memory["conversation_history"].append(entry)
-        if self.conversation_history_window and len(self.memory["conversation_history"]) > self.conversation_history_window:
-            del self.memory["conversation_history"][:-self.conversation_history_window]
+        self.memory["conversation_history"][:] = self.memory["conversation_history"][-self.conversation_history_window:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.2"
+version = "0.1.3"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"

--- a/tests/agents/test_standard_agent.py
+++ b/tests/agents/test_standard_agent.py
@@ -1,6 +1,7 @@
 from typing import Any, Deque, Dict, List, Optional, Tuple
 
 import pytest
+import json
 
 from agents.standard_agent import StandardAgent, AgentState
 from agents.reasoner.base import BaseReasoner, ReasoningResult
@@ -205,4 +206,30 @@ def test_agent_initial_state_is_ready():
 
     assert agent.state == AgentState.READY
 
+
+
+def test_agent_memory_is_json_serializable(monkeypatch):
+    llm = DummyLLM(text_queue=["S1", "S2"])
+    tools = DummyTools()
+    memory: Dict[str, Any] = DictMemory()
+    agent = StandardAgent(llm=llm, tools=tools, memory=memory, reasoner=DummyReasoner(), conversation_history_window=2)
+
+    agent.solve("g1")
+    agent.solve("g2")
+
+    dumped = json.dumps(agent.memory)
+    assert isinstance(dumped, str)
+    assert isinstance(agent.memory.get("conversation_history"), list)
+    assert len(agent.memory["conversation_history"]) == 2
+
+
+def test_agent_conversation_history_disabled_window():
+    llm = DummyLLM(text_queue=["S"])  # summarizer output
+    tools = DummyTools()
+    memory: Dict[str, Any] = DictMemory()
+    agent = StandardAgent(llm=llm, tools=tools, memory=memory, reasoner=DummyReasoner(), conversation_history_window=0)
+
+    agent.solve("g1")
+
+    assert memory.get("conversation_history") == []
 

--- a/tests/agents/test_standard_agent.py
+++ b/tests/agents/test_standard_agent.py
@@ -88,10 +88,6 @@ def test_agent_solve_sets_final_answer_from_summarizer_and_records_history(monke
     assert hist[-1]["goal"] == "find answer"
     assert hist[-1]["result"] == "SUMMARIZED"
 
-    # Goal and result stored with deterministic run id
-    assert memory.get("goal:RUN123") == "find answer"
-    assert isinstance(memory.get("result:RUN123"), ReasoningResult)
-
 
 def test_agent_uses_goal_preprocessor_and_returns_intervention_message(monkeypatch):
     _fixed_uuid4(monkeypatch, "RUNINT")


### PR DESCRIPTION
## Why
- json.dumps(agent.memory) failed due to:
- deque in conversation_history not being JSON-serializable.

## What changed
- Conversation history
  - Switched conversation_history to a plain list.
  - Added a tiny helper (_record_interaction) to append and trim in-place using slice assignment, preserving list identity.
  - Supports disabling via conversation_history_window <= 0.
  
##  Impact
- agent.memory is now directly JSON-serializable with no custom encoder.
- Conversation history behavior remains bounded and simple; performance unchanged for small windows.

### Note
- Minor breaking change: result:<run_id> and goal:<run_id> are no longer written to memory.
  - Rationale: they were never consumed by runtime code; only tests used them for verification.