### PR TITLE
Bug fix: Param generation crashes on non‑dict JSON

### DIFF
--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -102,15 +102,15 @@ param_gen: |
   </data_extraction_rules>
 
   <instructions>
-    1. Analyze MEMORY for relevant data structures.
-    2. Extract actual values using the data extraction rules.
-    3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
-    4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
-    5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
-    6. Unnecessary placeholders are strictly forbidden.
-    7. If a key is in REQUIRED_KEYS and you cannot find a real value:
-       • If SCHEMA type is "string": set value to "" (empty string).
-       • Otherwise: omit the key (do NOT fabricate or cast).
+  1. Analyze MEMORY for relevant data structures.
+  2. Extract actual values using the data extraction rules.
+  3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
+  4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
+  5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
+  6. Unnecessary placeholders are strictly forbidden.
+  7. If a key is in REQUIRED_KEYS and you cannot find a real value:
+    • If SCHEMA type is "string": set value to "" (empty string).
+    • Otherwise: omit the key (do NOT fabricate or cast).
   </instructions>
 
   <constraints>

--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -107,7 +107,7 @@ param_gen: |
   3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
   4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
   5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
-  6. Unnecessary placeholders are strictly forbidden.
+  6. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
   7. If a key is in REQUIRED_KEYS and you cannot find a real value:
     • If SCHEMA type is "string": set value to "" (empty string).
     • Otherwise: omit the key (do NOT fabricate or cast).

--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -102,20 +102,41 @@ param_gen: |
   </data_extraction_rules>
 
   <instructions>
-  1. Extract actual values using the rules
-  2. CRITICAL: Check STEP text for quantity constraints
-  3. Format content appropriately for the target API
-  4. Generate valid parameters using only ALLOWED_KEYS
-  5. CRITICAL: Only use parameters documented in the SCHEMA
+    1. Analyze MEMORY for relevant data structures.
+    2. Extract actual values using the data extraction rules.
+    3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
+    4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
+    5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
+    6. Unnecessary placeholders are strictly forbidden.
+    7. If a key is in REQUIRED_KEYS and you cannot find a real value:
+       • If SCHEMA type is "string": set value to "" (empty string).
+       • Otherwise: omit the key (do NOT fabricate or cast).
   </instructions>
 
   <constraints>
-  - Output ONLY valid JSON - no markdown or commentary
-  - Use only keys from ALLOWED_KEYS
-  - Extract actual data values from DATA
+  - Output MUST be a single JSON object at the top level (no arrays/scalars).
+  - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
+  - Keys MUST be a subset of ALLOWED_KEYS.
+  - Absolutely NO placeholders
   </constraints>
-
+  
   <output_format>
-  Valid JSON object starting with {{ and ending with }}
+  A single JSON object with only ALLOWED_KEYS. Example:
+  {{"parameter1": "value1", "count": 2}}
   </output_format>
+  
+  <bad_examples>
+  ["value1", "value2"]           // Bad: top-level array
+  "value"                        // Bad: scalar
+  {{parameter1: value1}}           // Bad: invalid JSON (unquoted)
+  ```json {{ "a": 1 }} ```         // Bad: fenced code block
+  </bad_examples>
+
+  <self_check>
+  Before responding, verify ALL of the following:
+  - Top-level is a JSON object (starts with {{ and ends with }}).
+  - All keys are from ALLOWED_KEYS only.
+  - JSON is syntactically valid and parsable.
+  If any check fails, regenerate your answer to satisfy all constraints.
+  </self_check>
 

--- a/agents/prompts/reasoners/rewoo.yaml
+++ b/agents/prompts/reasoners/rewoo.yaml
@@ -187,26 +187,43 @@ param_gen: |
     </data_extraction_rules>
 
     <instructions>
-    1. Analyze MEMORY for relevant data structures
-    2. Extract actual values using the data extraction rules
-    3. **CRITICAL**: Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items")
-    4. If processing arrays from memory and STEP has quantity constraint, slice array to that size
-    5. Format content appropriately for the target API
-    6. Generate valid parameters using only ALLOWED_KEYS
-    7. **CRITICAL**: Only use parameters that are explicitly documented in the SCHEMA - do not infer or add undocumented parameters
+    1. Analyze MEMORY for relevant data structures.
+    2. Extract actual values using the data extraction rules.
+    3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
+    4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
+    5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
+    6. Unnecessary placeholders are strictly forbidden.
+    7. If a key is in REQUIRED_KEYS and you cannot find a real value:
+       • If SCHEMA type is "string": set value to "" (empty string).
+       • Otherwise: omit the key (do NOT fabricate or cast).
     </instructions>
 
     <constraints>
-    - Output ONLY valid JSON - no markdown, explanations, or backticks
-    - Use only keys from ALLOWED_KEYS
-    - Extract actual data values from MEMORY, never placeholder text
-    - For messaging APIs: format as readable text with titles and links
-    - Required parameters take priority over optional ones
+    - Output MUST be a single JSON object at the top level (no arrays/scalars).
+    - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
+    - Keys MUST be a subset of ALLOWED_KEYS.
+    - Absolutely NO placeholders
     </constraints>
-
+  
     <output_format>
-    Valid JSON object starting with {{ and ending with }}
+    A single JSON object with only ALLOWED_KEYS. Example:
+    {{"parameter1": "value1", "count": 2}}
     </output_format>
+  
+    <bad_examples>
+    ["value1", "value2"]           // Bad: top-level array
+    "value"                        // Bad: scalar
+    {{parameter1: value1}}           // Bad: invalid JSON (unquoted)
+    ```json {{ "a": 1 }} ```         // Bad: fenced code block
+    </bad_examples>
+
+    <self_check>
+    Before responding, verify ALL of the following:
+    - Top-level is a JSON object (starts with {{ and ends with }}).
+    - All keys are from ALLOWED_KEYS only.
+    - JSON is syntactically valid and parsable.
+    If any check fails, regenerate your answer to satisfy all constraints.
+    </self_check>
 
 reflect: |
   <role>

--- a/agents/prompts/reasoners/rewoo.yaml
+++ b/agents/prompts/reasoners/rewoo.yaml
@@ -192,7 +192,7 @@ param_gen: |
     3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
     4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
     5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
-    6. Unnecessary placeholders are strictly forbidden.
+    6. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
     7. If a key is in REQUIRED_KEYS and you cannot find a real value:
        • If SCHEMA type is "string": set value to "" (empty string).
        • Otherwise: omit the key (do NOT fabricate or cast).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.3"
+version = "0.1.4"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"


### PR DESCRIPTION

**Issue**
- Agent crashed with "list object has no attribute items" during parameter generation.
- LLM sometimes emitted a list (e.g., [["text"]]) or reflection returned non-dict params.

**Why it happened**
- Code assumed param-gen output is always a dict and called .items() unguarded.
- Prompt allowed “any valid JSON,” so lists were valid outputs; no explicit ban on placeholders.

**Fixes**
- ReWOO: Catch AttributeError in param-gen; guard reflector retry_params to raise ParameterGenerationError when params isn’t a dict.
- ReACT: Param-gen now raises ParameterGenerationError on non-dict/invalid JSON; ACT handler catches and logs it.
- Prompts: Tightened param_gen to require a top-level JSON object, valid JSON (quoted keys), forbid placeholders and Guidance to wrap lists only under the single array-typed key when applicable.

**Tests**
- ReWOO: non-dict param-gen raises error; non-dict during run triggers reflection; non-dict reflector params triggers error and second reflection.
- ReACT: non-dict param-gen raises error (direct) and logs error during run; no tool calls recorded.

**Impact**
- No more crashes on non-dict param outputs; bad suggestions don’t propagate. [Better error handling]
- Cleaner traces; failures route through reflection/self-healing.
- Stricter prompts reduce likelihood of malformed/placeholder params.