### PR TITLE
Add Required Parameter Support for Tool Parameter Generation

### DIFF
--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -90,6 +90,7 @@ param_gen: |
   DATA: {data}
   SCHEMA: {schema}
   ALLOWED_KEYS: {allowed_keys}
+  REQUIRED_KEYS: {required_keys}
   </input>
 
   <data_extraction_rules>
@@ -102,21 +103,23 @@ param_gen: |
   </data_extraction_rules>
 
   <instructions>
-  1. Analyze MEMORY for relevant data structures.
+  1. Analyze DATA for relevant data structures.
   2. Extract actual values using the data extraction rules.
   3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
   4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
   5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
-  6. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
+  6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
   7. If a key is in REQUIRED_KEYS and you cannot find a real value:
     • If SCHEMA type is "string": set value to "" (empty string).
     • Otherwise: omit the key (do NOT fabricate or cast).
+  8. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
   </instructions>
 
   <constraints>
   - Output MUST be a single JSON object at the top level (no arrays/scalars).
   - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
   - Keys MUST be a subset of ALLOWED_KEYS.
+  - All keys in REQUIRED_KEYS must be present in the output.
   - Absolutely NO placeholders
   </constraints>
   

--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -109,10 +109,7 @@ param_gen: |
   4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
   5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
   6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
-  7. If a key is in REQUIRED_KEYS and you cannot find a real value:
-    • If SCHEMA type is "string": set value to "" (empty string).
-    • Otherwise: omit the key (do NOT fabricate or cast).
-  8. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
+  7. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
   </instructions>
 
   <constraints>

--- a/agents/prompts/reasoners/rewoo.yaml
+++ b/agents/prompts/reasoners/rewoo.yaml
@@ -194,10 +194,7 @@ param_gen: |
     4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
     5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
     6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
-    7. If a key is in REQUIRED_KEYS and you cannot find a real value:
-       • If SCHEMA type is "string": set value to "" (empty string).
-       • Otherwise: omit the key (do NOT fabricate or cast).
-    8. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
+    7. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
     </instructions>
 
     <constraints>

--- a/agents/prompts/reasoners/rewoo.yaml
+++ b/agents/prompts/reasoners/rewoo.yaml
@@ -175,6 +175,7 @@ param_gen: |
     MEMORY: {step_inputs}
     SCHEMA: {tool_schema}
     ALLOWED_KEYS: {allowed_keys}
+    REQUIRED_KEYS: {required_keys}
     </input>
 
     <data_extraction_rules>
@@ -192,16 +193,18 @@ param_gen: |
     3. **CRITICAL** Check STEP text for quantity constraints (e.g., "send 3 articles", "post 2 items").
     4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
     5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
-    6. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
+    6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
     7. If a key is in REQUIRED_KEYS and you cannot find a real value:
        • If SCHEMA type is "string": set value to "" (empty string).
        • Otherwise: omit the key (do NOT fabricate or cast).
+    8. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
     </instructions>
 
     <constraints>
     - Output MUST be a single JSON object at the top level (no arrays/scalars).
     - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
     - Keys MUST be a subset of ALLOWED_KEYS.
+    - All keys in REQUIRED_KEYS must be present in the output.
     - Absolutely NO placeholders
     </constraints>
   

--- a/agents/reasoner/rewoo.py
+++ b/agents/reasoner/rewoo.py
@@ -206,19 +206,34 @@ class ReWOOReasoner(BaseReasoner):
     def _generate_params(self, step: Step, tool: ToolBase, inputs: Dict[str, Any]) -> Dict[str, Any]:
         try:
             param_schema = tool.get_parameters() or {}
+            required_keys = tool.get_required_parameters() if hasattr(tool, 'get_required_parameters') else []
+            
+            # Get params from either reflector suggestion or LLM generation
             suggestion = self.memory.pop(f"rewoo_reflector_suggestion:{step.text}", None)
             if suggestion and suggestion["action"] == "retry_params" and "params" in suggestion:
                 logger.info("using_reflector_suggested_params", step_text=step.text, params=suggestion["params"])
-                return {k: v for k, v in suggestion["params"].items() if k in param_schema}
-
-            prompt = _PROMPTS["param_gen"].format(
-                step=step.text,
-                tool_schema=json.dumps(param_schema, ensure_ascii=False),
-                step_inputs=json.dumps(inputs, ensure_ascii=False),
-                allowed_keys=",".join(param_schema.keys()),
-            )
-            params_raw = self.llm.prompt_to_json(prompt, max_retries=self.max_retries)
-            return {k: v for k, v in (params_raw or {}).items() if k in param_schema}
+                final_params = {k: v for k, v in suggestion["params"].items() if k in param_schema}
+            else:
+                prompt = _PROMPTS["param_gen"].format(
+                    step=step.text,
+                    tool_schema=json.dumps(param_schema, ensure_ascii=False),
+                    step_inputs=json.dumps(inputs, ensure_ascii=False),
+                    allowed_keys=",".join(param_schema.keys()),
+                    required_keys=",".join(required_keys),
+                )
+                params_raw = self.llm.prompt_to_json(prompt, max_retries=self.max_retries)
+                final_params = {k: v for k, v in (params_raw or {}).items() if k in param_schema}
+            
+            # Single validation point for required parameters
+            missing_required_parameter = [key for key in required_keys if key not in final_params]
+            if missing_required_parameter:
+                logger.warning("missing_required_parameters", step_text=step.text, tool_id=tool.id, missing_parameters=missing_required_parameter, generated_parameters=final_params, required_parameters=required_keys)
+                raise ParameterGenerationError(
+                    f"Parameters for step '{step.text}' are missing required parameters: {', '.join(missing_required_parameter)}. "
+                    f"Generated parameters: {final_params}. Tool '{tool.id}' requires these parameters for successful execution.", tool
+                )
+            logger.info("params_generated", tool_id=tool.id, params=final_params)
+            return final_params
         except (json.JSONDecodeError, TypeError, ValueError, AttributeError) as e:
             raise ParameterGenerationError(f"Failed to generate valid JSON parameters for step '{step.text}': {e}", tool) from e
 

--- a/agents/reasoner/rewoo.py
+++ b/agents/reasoner/rewoo.py
@@ -224,7 +224,6 @@ class ReWOOReasoner(BaseReasoner):
                 params_raw = self.llm.prompt_to_json(prompt, max_retries=self.max_retries)
                 final_params = {k: v for k, v in (params_raw or {}).items() if k in param_schema}
             
-            # Single validation point for required parameters
             missing_required_parameter = [key for key in required_keys if key not in final_params]
             if missing_required_parameter:
                 logger.warning("missing_required_parameters", step_text=step.text, tool_id=tool.id, missing_parameters=missing_required_parameter, generated_parameters=final_params, required_parameters=required_keys)

--- a/agents/tools/jentic.py
+++ b/agents/tools/jentic.py
@@ -39,7 +39,7 @@ class JenticTool(ToolBase):
         self.api_name = schema.get('api_name', 'unknown')
         self.method = schema.get('method')  # For operations
         self.path = schema.get('path')      # For operations
-        self.required = schema.get('inputs', {}).get('required', []),
+        self.required = schema.get('inputs', {}).get('required', [])
         self._parameters = schema.get('inputs', {}).get('properties', None)
 
     def __str__(self) -> str:
@@ -60,6 +60,13 @@ class JenticTool(ToolBase):
     def get_parameters(self) -> Dict[str, Any]:
         """Return detailed parameter schema for LLM parameter generation."""
         return self._parameters
+
+    def get_required_parameters(self) -> List[str]:
+        """Return list of required parameter names that exist in the schema properties."""
+        if not self.required or not self._parameters:
+            return []
+        # Filter to only include required fields that actually exist in properties
+        return [key for key in self.required if key in self._parameters]
 
 
 class JenticClient(JustInTimeToolingBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.4"
+version = "0.1.5"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"

--- a/tests/tools/test_jentic.py
+++ b/tests/tools/test_jentic.py
@@ -139,6 +139,63 @@ class TestJenticTool:
         parameters = tool.get_parameters()
         assert parameters == None
 
+    def test_get_required_parameters_with_valid_required_fields(self):
+        """
+        Tests get_required_parameters returns required fields that exist in properties.
+        """
+        tool = JenticTool(WORKFLOW_SCHEMA)
+        required_params = tool.get_required_parameters()
+        assert required_params == ['param1']
+
+    def test_get_required_parameters_filters_invalid_fields(self):
+        """
+        Tests get_required_parameters filters out required fields that don't exist in properties.
+        """
+        schema_with_invalid_required = {
+            'workflow_id': 'wf_test',
+            'inputs': {
+                'required': ['param1', 'nonexistent_param'],
+                'properties': {
+                    'param1': {'type': 'string'},
+                    'param2': {'type': 'integer'}
+                }
+            }
+        }
+        tool = JenticTool(schema_with_invalid_required)
+        required_params = tool.get_required_parameters()
+        assert required_params == ['param1']  # nonexistent_param filtered out
+
+    def test_get_required_parameters_empty_required(self):
+        """
+        Tests get_required_parameters returns empty list when no required fields.
+        """
+        tool = JenticTool(OPERATION_SCHEMA)  # has empty required array
+        required_params = tool.get_required_parameters()
+        assert required_params == []
+
+    def test_get_required_parameters_no_inputs(self):
+        """
+        Tests get_required_parameters returns empty list when no inputs section.
+        """
+        tool = JenticTool(EMPTY_SCHEMA)
+        required_params = tool.get_required_parameters()
+        assert required_params == []
+
+    def test_get_required_parameters_no_properties(self):
+        """
+        Tests get_required_parameters returns empty list when no properties section.
+        """
+        schema_no_properties = {
+            'workflow_id': 'wf_test',
+            'inputs': {
+                'required': ['param1']
+                # no properties section
+            }
+        }
+        tool = JenticTool(schema_no_properties)
+        required_params = tool.get_required_parameters()
+        assert required_params == []
+
 
 @pytest.fixture
 def mock_jentic_sdk():

--- a/tests/tools/test_jentic.py
+++ b/tests/tools/test_jentic.py
@@ -54,7 +54,7 @@ class TestJenticTool:
         assert tool.name == 'Test Workflow'
         assert tool.description == 'A test workflow for unit tests.'
         assert tool.api_name == 'test_api'
-        assert tool.required == (['param1'],)
+        assert tool.required == (['param1'])
         assert tool.get_parameters() == {
             'param1': {'type': 'string'},
             'param2': {'type': 'integer'}


### PR DESCRIPTION
## TL;DR
Enhanced parameter generation to use required parameter information from tool schemas, improving first-pass success rates and providing better error messages when required parameters are missing.

## Issue
- The current parameter generation system in both ReWOO and ReACT reasoners ignores required parameter information from tool schemas, leading to:
- Unnecessary failures: LLMs generate incomplete parameter sets missing required fields
- Wasted API calls: Failed executions trigger reflection/retry cycles that could be avoided
- Poor debugging experience: Generic parameter generation errors without specific details about what was missing
- Unused schema data: JenticTool extracts required fields from schemas but never uses them

The system would attempt parameter generation, fail at execution time, then use reflection mechanisms to retry - an inefficient approach when the required parameters could be explicitly communicated to the LLM upfront.

## Opportunity
- Tool schemas from the Jentic API often include required parameter lists that specify which fields are mandatory for successful execution. By leveraging this information, we can:
- Improve first-pass success rates: Give LLMs explicit guidance about mandatory parameters
- Reduce retry cycles: Catch missing required parameters before execution
- Enhance debugging: Provide specific error messages showing what was generated vs. what was required
- Maintain backward compatibility: Gracefully handle tools without required parameter information

## Fix

### Core Changes
1. JenticTool Enhancement
Fixed tuple bug in self.required assignment
Added get_required_parameters() method with schema validation

2. Prompt Updates
Added REQUIRED_KEYS input to ReWOO and ReACT param_gen prompts
Enhanced instructions to explicitly require mandatory parameters

3. Parameter Generation
Updated both reasoners to pass required keys to prompts
Added post-generation validation with detailed error messages
Enhanced logging for debugging parameter generation failures

PS: @DavidAtJentic Thanks for spotting and reporting this gap. 