### PR TITLE
Add input validation to StandardAgent.solve() - Fixes #76

### DIFF
--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -71,6 +71,12 @@ class StandardAgent:
 
     def solve(self, goal: str) -> ReasoningResult:
         """Solves a goal synchronously (library-style API)."""
+        
+        if goal is None:
+            raise ValueError("Goal cannot be None")
+        if not goal or not goal.strip():
+            raise ValueError("Goal cannot be empty or whitespace")
+        
         run_id = uuid4().hex
         start_time = time.perf_counter()
 

--- a/tests/agents/test_standard_agent.py
+++ b/tests/agents/test_standard_agent.py
@@ -232,4 +232,42 @@ def test_agent_conversation_history_disabled_window():
     agent.solve("g1")
 
     assert memory.get("conversation_history") == []
+    
+def test_solve_raises_error_for_none_goal():
+    """Test that solve raises ValueError when goal is None"""
+    agent = StandardAgent(
+        llm=DummyLLM(),
+        tools=DummyTools(),
+        memory=DictMemory(),
+        reasoner=DummyReasoner()
+    )
+    
+    with pytest.raises(ValueError, match="Goal cannot be None"):
+        agent.solve(None)
+
+
+def test_solve_raises_error_for_empty_goal():
+    """Test that solve raises ValueError when goal is empty string"""
+    agent = StandardAgent(
+        llm=DummyLLM(),
+        tools=DummyTools(), 
+        memory=DictMemory(),
+        reasoner=DummyReasoner()
+    )
+    
+    with pytest.raises(ValueError, match="Goal cannot be empty or whitespace"):
+        agent.solve("")
+
+
+def test_solve_raises_error_for_whitespace_goal():
+    """Test that solve raises ValueError when goal is only whitespace"""
+    agent = StandardAgent(
+        llm=DummyLLM(),
+        tools=DummyTools(),
+        memory=DictMemory(), 
+        reasoner=DummyReasoner()
+    )
+    
+    with pytest.raises(ValueError, match="Goal cannot be empty or whitespace"):
+        agent.solve("   ")
 


### PR DESCRIPTION
Closes #76
   
   This PR adds input validation to the `solve()` method as requested in the issue:
   
   - Validates goal is not None or empty/whitespace
   - Raises appropriate ValueError exceptions  
   - Includes comprehensive unit tests
   - All existing tests continue to pass (12/12 passing)
   
   The implementation follows the existing code patterns and testing conventions.