### PR TITLE
Encourage "<UNKNOWN>" token in param generation for uninferable required params to aid reflection

### DIFF
--- a/agents/prompts/reasoners/react.yaml
+++ b/agents/prompts/reasoners/react.yaml
@@ -109,7 +109,9 @@ param_gen: |
   4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
   5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
   6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
-  7. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc.
+  7. **CRITICAL** For credential/authentication parameters (like "key", "token", "api_key", "authorization"), use empty string "" when no value is available in the data.
+  8. **CRITICAL** For required data parameters where you cannot find real values in the available data, use "<UNKNOWN>" to explicitly indicate missing information.
+  9. Never fabricate, guess, or make up parameter values - be honest about what data is missing.
   </instructions>
 
   <constraints>
@@ -117,7 +119,7 @@ param_gen: |
   - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
   - Keys MUST be a subset of ALLOWED_KEYS.
   - All keys in REQUIRED_KEYS must be present in the output.
-  - Absolutely NO placeholders
+  - Use "<UNKNOWN>" only for required data parameters when real values cannot be found.
   </constraints>
   
   <output_format>

--- a/agents/prompts/reasoners/rewoo.yaml
+++ b/agents/prompts/reasoners/rewoo.yaml
@@ -194,7 +194,9 @@ param_gen: |
     4. **CRITICAL** Map values to SCHEMA keys using exact names. Do not invent or rename keys.
     5. **CRITICAL** Use only keys listed in ALLOWED_KEYS. Omit any key you cannot populate truthfully.
     6. **CRITICAL** All keys in REQUIRED_KEYS must be included in your output. These are mandatory parameters for successful API execution.
-    7. Placeholders for unknown values are strictly forbidden: ex "<UNKNOWN>", etc. 
+    7. **CRITICAL** For credential/authentication parameters (like "key", "token", "api_key", "authorization"), use empty string "" when no value is available in the data.
+    8. **CRITICAL** For required data parameters where you cannot find real values in the available data, use "<UNKNOWN>" to explicitly indicate missing information.
+    9. Never fabricate, guess, or make up parameter values - be honest about what data is missing.
     </instructions>
 
     <constraints>
@@ -202,7 +204,7 @@ param_gen: |
     - Output ONLY valid JSON: double-quoted keys and strings, no comments, no markdown, no backticks.
     - Keys MUST be a subset of ALLOWED_KEYS.
     - All keys in REQUIRED_KEYS must be present in the output.
-    - Absolutely NO placeholders
+    - Use "<UNKNOWN>" only for required data parameters when real values cannot be found.
     </constraints>
   
     <output_format>

--- a/agents/reasoner/exceptions.py
+++ b/agents/reasoner/exceptions.py
@@ -25,6 +25,3 @@ class ToolSelectionError(ReasoningError):
 class ParameterGenerationError(ToolError):
     """Valid parameters for a tool could not be generated."""
 
-
-
-

--- a/agents/reasoner/exceptions.py
+++ b/agents/reasoner/exceptions.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
 from agents.tools.exceptions import ToolError
-from agents.tools.base import ToolBase
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -28,27 +26,5 @@ class ParameterGenerationError(ToolError):
     """Valid parameters for a tool could not be generated."""
 
 
-class UnknownParameterError(ParameterGenerationError):
-    """LLM explicitly marked required parameters as <UNKNOWN>. LLM is encouraged to use <UNKNOWN> for parameters it cannot infer from the given context."""
-    
-    def __init__(self, tool: ToolBase, unknown_params: List[str], step_text: str, generated_params: Dict[str, Any]):
-        self.unknown_params = unknown_params
-        message = (
-            f"LLM indicated missing data for parameters: {', '.join(unknown_params)} in step '{step_text}'. "
-            f"Generated parameters: {generated_params}. Tool '{tool.id}' requires these parameters for successful execution."
-        )
-        super().__init__(message, tool)
-
-
-class MissingParameterError(ParameterGenerationError):
-    """LLM omitted required parameters entirely."""
-    
-    def __init__(self, tool: ToolBase, missing_params: List[str], step_text: str, generated_params: Dict[str, Any]):
-        self.missing_params = missing_params
-        message = (
-            f"Generated parameters missing required keys: {', '.join(missing_params)} for step '{step_text}'. "
-            f"Generated parameters: {generated_params}. Tool '{tool.id}' requires these parameters for successful execution."
-        )
-        super().__init__(message, tool)
 
 

--- a/agents/reasoner/exceptions.py
+++ b/agents/reasoner/exceptions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from typing import Any, Dict, List
 from agents.tools.exceptions import ToolError
+from agents.tools.base import ToolBase
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -24,5 +26,29 @@ class ToolSelectionError(ReasoningError):
 
 class ParameterGenerationError(ToolError):
     """Valid parameters for a tool could not be generated."""
+
+
+class UnknownParameterError(ParameterGenerationError):
+    """LLM explicitly marked required parameters as <UNKNOWN>. LLM is encouraged to use <UNKNOWN> for parameters it cannot infer from the given context."""
+    
+    def __init__(self, tool: ToolBase, unknown_params: List[str], step_text: str, generated_params: Dict[str, Any]):
+        self.unknown_params = unknown_params
+        message = (
+            f"LLM indicated missing data for parameters: {', '.join(unknown_params)} in step '{step_text}'. "
+            f"Generated parameters: {generated_params}. Tool '{tool.id}' requires these parameters for successful execution."
+        )
+        super().__init__(message, tool)
+
+
+class MissingParameterError(ParameterGenerationError):
+    """LLM omitted required parameters entirely."""
+    
+    def __init__(self, tool: ToolBase, missing_params: List[str], step_text: str, generated_params: Dict[str, Any]):
+        self.missing_params = missing_params
+        message = (
+            f"Generated parameters missing required keys: {', '.join(missing_params)} for step '{step_text}'. "
+            f"Generated parameters: {generated_params}. Tool '{tool.id}' requires these parameters for successful execution."
+        )
+        super().__init__(message, tool)
 
 

--- a/agents/reasoner/react.py
+++ b/agents/reasoner/react.py
@@ -8,7 +8,7 @@ from agents.reasoner.base import BaseReasoner, ReasoningResult
 from agents.llm.base_llm import BaseLLM
 from agents.tools.base import JustInTimeToolingBase, ToolBase
 from agents.tools.exceptions import ToolExecutionError, ToolCredentialsMissingError
-from agents.reasoner.exceptions import ToolSelectionError, ParameterGenerationError
+from agents.reasoner.exceptions import ToolSelectionError, ParameterGenerationError, UnknownParameterError, MissingParameterError
 
 
 from utils.logger import get_logger
@@ -149,13 +149,15 @@ class ReACTReasoner(BaseReasoner):
             ) or {}
             final_params: Dict[str, Any] = {k: v for k, v in params_raw.items() if k in schema}
             
-            missing_required_parameter = [key for key in required_keys if key not in final_params]
-            if missing_required_parameter:
-                logger.warning("missing_required_parameters", step_text=step_text, tool_id=tool.id, missing_parameters=missing_required_parameter, generated_parameters=final_params, required_parameters=required_keys)
-                raise ParameterGenerationError(
-                    f"Parameters for step '{step_text}' are missing required parameters: {', '.join(missing_required_parameter)}. "
-                    f"Generated parameters: {final_params}. Tool '{tool.id}' requires these parameters for successful execution.", tool
-                )
+            unknown_params = [k for k, v in final_params.items() if v == "<UNKNOWN>"]
+            if unknown_params:
+                logger.warning("parameters_marked_unknown", step_text=step_text, tool_id=tool.id, unknown_parameters=unknown_params, generated_parameters=final_params, required_parameters=required_keys)
+                raise UnknownParameterError(tool, unknown_params, step_text, final_params)
+            
+            missing_params = [key for key in required_keys if key not in final_params]
+            if missing_params:
+                logger.warning("missing_required_parameters", step_text=step_text, tool_id=tool.id, missing_parameters=missing_params, generated_parameters=final_params, required_parameters=required_keys)
+                raise MissingParameterError(tool, missing_params, step_text, final_params)
             
             logger.info("params_generated", tool_id=tool.id, params=final_params)
             return final_params

--- a/agents/reasoner/react.py
+++ b/agents/reasoner/react.py
@@ -8,8 +8,7 @@ from agents.reasoner.base import BaseReasoner, ReasoningResult
 from agents.llm.base_llm import BaseLLM
 from agents.tools.base import JustInTimeToolingBase, ToolBase
 from agents.tools.exceptions import ToolExecutionError, ToolCredentialsMissingError
-from agents.reasoner.exceptions import ToolSelectionError, ParameterGenerationError, UnknownParameterError, MissingParameterError
-
+from agents.reasoner.exceptions import ToolSelectionError, ParameterGenerationError
 
 from utils.logger import get_logger
 logger = get_logger(__name__)
@@ -149,15 +148,17 @@ class ReACTReasoner(BaseReasoner):
             ) or {}
             final_params: Dict[str, Any] = {k: v for k, v in params_raw.items() if k in schema}
             
-            unknown_params = [k for k, v in final_params.items() if v == "<UNKNOWN>"]
-            if unknown_params:
-                logger.warning("parameters_marked_unknown", step_text=step_text, tool_id=tool.id, unknown_parameters=unknown_params, generated_parameters=final_params, required_parameters=required_keys)
-                raise UnknownParameterError(tool, unknown_params, step_text, final_params)
-            
+            unknown_params = [key for key, val in final_params.items() if val == "<UNKNOWN>"]
             missing_params = [key for key in required_keys if key not in final_params]
-            if missing_params:
-                logger.warning("missing_required_parameters", step_text=step_text, tool_id=tool.id, missing_parameters=missing_params, generated_parameters=final_params, required_parameters=required_keys)
-                raise MissingParameterError(tool, missing_params, step_text, final_params)
+            
+            if unknown_params or missing_params:
+                error_message_parts = []
+                if unknown_params: error_message_parts.append(f"LLM indicated missing data for parameters: {', '.join(unknown_params)}")
+                if missing_params: error_message_parts.append(f"Missing required parameters: {', '.join(missing_params)}")
+
+                param_gen_error = f"{' | '.join(error_message_parts)} in step '{step_text}'. Generated parameters: {final_params}. Tool '{tool.id}' requires these parameters for successful execution."
+                logger.error("parameter_generation_failed", error = param_gen_error, step_text=step_text, tool_id=tool.id, generated_parameters=final_params, required_parameters=required_keys)
+                raise ParameterGenerationError(f"{' | '.join(error_message_parts)} in step '{step_text}'. Generated parameters: {final_params}. Tool '{tool.id}' requires these parameters for successful execution.", tool)
             
             logger.info("params_generated", tool_id=tool.id, params=final_params)
             return final_params

--- a/agents/reasoner/react.py
+++ b/agents/reasoner/react.py
@@ -153,7 +153,7 @@ class ReACTReasoner(BaseReasoner):
             
             if unknown_params or missing_params:
                 error_message_parts = []
-                if unknown_params: error_message_parts.append(f"LLM indicated missing data for parameters: {', '.join(unknown_params)}")
+                if unknown_params: error_message_parts.append(f"LLM indicated missing data using <UNKNOWN> for parameters: {', '.join(unknown_params)}")
                 if missing_params: error_message_parts.append(f"Missing required parameters: {', '.join(missing_params)}")
 
                 param_gen_error = f"{' | '.join(error_message_parts)} in step '{step_text}'. Generated parameters: {final_params}. Tool '{tool.id}' requires these parameters for successful execution."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.5"
+version = "0.1.6"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"

--- a/tests/agents/reasoners/test_react.py
+++ b/tests/agents/reasoners/test_react.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from agents.reasoner.react import ReACTReasoner
 from agents.memory.dict_memory import DictMemory
@@ -383,6 +383,51 @@ def test_react_required_params_full_integration():
     assert result.tool_calls == []
     assert "ParameterGenerationError" in result.transcript
     assert "Missing required parameters: required_param" in result.transcript
+
+
+def test_react_generate_params_unknown_required_params_raises_error():
+    """Test _generate_params raises ParameterGenerationError when LLM returns <UNKNOWN> for required params."""
+    class ToolWithRequired(DummyTool):
+        def __init__(self, tool_id: str, name: str):
+            # Include both param1 (required) and param2 (optional) in schema so both pass filtering
+            super().__init__(tool_id, name, schema={"param1": {}, "param2": {}})
+        def get_required_parameters(self) -> List[str]:
+            return ["param1"]
+    
+    llm = DummyLLM(json_queue=[{"param1": "<UNKNOWN>", "param2": "value2"}])
+    tool = ToolWithRequired("t1", "Tool One")
+    reasoner = ReACTReasoner(llm=llm, tools=[tool], memory=DictMemory())
+    
+    with pytest.raises(ParameterGenerationError) as exc:
+        reasoner._generate_params(tool, transcript="test transcript", step_text="test step")
+    
+    error_msg = str(exc.value)
+    assert "LLM indicated missing data using <UNKNOWN> for parameters: param1" in error_msg
+    assert "Generated parameters: {'param1': '<UNKNOWN>', 'param2': 'value2'}" in error_msg
+    assert "Tool 't1' requires these parameters" in error_msg
+
+
+def test_react_generate_params_combined_unknown_and_missing_params_raises_error():
+    """Test _generate_params raises ParameterGenerationError with both unknown and missing required params."""
+    class ToolWithRequired(DummyTool):
+        def __init__(self, tool_id: str, name: str):
+            # Only required params in schema; param4 will be filtered out
+            super().__init__(tool_id, name, schema={"param1": {}, "param2": {}, "param3": {}})
+        def get_required_parameters(self) -> List[str]:
+            return ["param1", "param2", "param3"]
+    
+    llm = DummyLLM(json_queue=[{"param1": "<UNKNOWN>", "param4": "value4"}])  # param1 is unknown, param2&3 missing
+    tool = ToolWithRequired("t1", "Tool One")
+    reasoner = ReACTReasoner(llm=llm, tools=[tool], memory=DictMemory())
+    
+    with pytest.raises(ParameterGenerationError) as exc:
+        reasoner._generate_params(tool, transcript="test transcript", step_text="test step")
+    
+    error_msg = str(exc.value)
+    assert "LLM indicated missing data using <UNKNOWN> for parameters: param1" in error_msg
+    assert "Missing required parameters: param2, param3" in error_msg
+    assert "Generated parameters: {'param1': '<UNKNOWN>'}" in error_msg  # param4 filtered out
+    assert "Tool 't1' requires these parameters" in error_msg
 
 
 def test_react_required_params_success_integration():

--- a/tests/agents/reasoners/test_react.py
+++ b/tests/agents/reasoners/test_react.py
@@ -308,7 +308,7 @@ def test_react_generate_params_missing_required_params_raises_error():
         reasoner._generate_params(tool, transcript="test transcript", step_text="test step")
     
     error_msg = str(exc.value)
-    assert "missing required parameters: param1" in error_msg
+    assert "Missing required parameters: param1" in error_msg
     assert "Generated parameters: {'param2': 'value2'}" in error_msg
     assert "Tool 't1' requires these parameters" in error_msg
 
@@ -382,7 +382,7 @@ def test_react_required_params_full_integration():
     # Should fail due to ParameterGenerationError, no tool call recorded
     assert result.tool_calls == []
     assert "ParameterGenerationError" in result.transcript
-    assert "missing required parameters: required_param" in result.transcript
+    assert "Missing required parameters: required_param" in result.transcript
 
 
 def test_react_required_params_success_integration():

--- a/tests/agents/reasoners/test_rewoo.py
+++ b/tests/agents/reasoners/test_rewoo.py
@@ -517,7 +517,7 @@ def test_rewoo_generate_params_missing_required_params_raises_error():
         reasoner._generate_params(step, tool, inputs={})
     
     error_msg = str(exc.value)
-    assert "missing required parameters: param1" in error_msg
+    assert "Missing required parameters: param1" in error_msg
     assert "Generated parameters: {'param2': 'value2'}" in error_msg
     assert "Tool 't1' requires these parameters" in error_msg
 
@@ -586,7 +586,7 @@ def test_rewoo_generate_params_reflector_suggested_params_missing_required():
         reasoner._generate_params(step, tool, inputs={})
     
     error_msg = str(exc.value)
-    assert "missing required parameters: param1" in error_msg
+    assert "Missing required parameters: param1" in error_msg
     assert "Generated parameters: {'param2': 'value2'}" in error_msg
 
 


### PR DESCRIPTION
**TL;DR:** LLM now emits \<UNKNOWN\> for required-but-uninferable params; validation treats it as missing and raises one detailed ParameterGenerationError (includes generated params), enabling reflection to fix

### Issue
- LLM had no explicit way to signal uninferable required data, causing guesses or silent omissions.
- Reflection couldn’t distinguish “unknown value” from “missing key,” reducing recovery quality.

### Opportunity
- Encourage explicit, honest signaling for uninferable required values.
- Improve reflection by providing precise diagnostics for unknown vs missing parameters.

### Fix
- Prompts
   - Encourage the LLM to output "<UNKNOWN>" for uninferable required parameters.
   - Allow empty string "" for credential/auth keys (e.g., "key", "token", "api_key") when unavailable.
 
- Validation
   - Treat "<UNKNOWN>" on required keys as a failure (same as missing).
   - Raise a single ParameterGenerationError naming unknown and missing keys and including full generated params and tool id.
 
 - Reflection
    - Leverages the detailed error to retry and fix parameters, with clear indication of which required values were unknown vs missing.