### PR TITLE
#74 type hints added

### DIFF
--- a/agents/memory/dict_memory.py
+++ b/agents/memory/dict_memory.py
@@ -1,27 +1,40 @@
-"""
-Simple dictionary-based memory implementation.
+"""Simple dictionary-based memory implementation."""
 
-This module provides a factory function for creating memory storage.
-Any MutableMapping implementation can be used as memory storage in the system.
-"""
-from typing import Any, Dict
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, TypedDict
 
 
-def DictMemory() -> Dict[str, Any]:
+class ConversationHistoryEntry(TypedDict, total=False):
+    """Structure for conversation history entries stored in memory."""
+
+    goal: str
+    result: str
+
+
+ConversationHistory = list[ConversationHistoryEntry]
+MemoryValue = Any
+MemoryStore = MutableMapping[str, MemoryValue]
+
+
+def DictMemory() -> MemoryStore:
     """
     Create a simple in-memory storage using a dictionary.
-    
+
     This is suitable for development, testing, and single-session use cases.
     Data is lost when the process terminates.
-    
+
     Returns:
-        Empty dictionary that implements MutableMapping interface
-        
+        Mutable mapping that can hold agent runtime state.
+
     Note:
-        This is just a regular Python dict. Any MutableMapping implementation
-        can be used as memory storage in place of this (Redis, custom classes, etc.).
-        Custom classes need only implement __getitem__, __setitem__, __delitem__, 
-        __iter__, and __len__ methods.
+        This is just a regular Python dict. Any MutableMapping implementation can be used
+        as memory storage in place of this (Redis, custom classes, etc.). Custom classes need
+        only implement ``__getitem__``, ``__setitem__``, ``__delitem__``, ``__iter__``, and
+        ``__len__`` methods.
     """
-    return {}
+
+    memory: MemoryStore = {}
+    return memory
 


### PR DESCRIPTION
- Added explicit type aliases and hints to DictMemory so it now returns a MutableMapping with documented conversation-history entries; runtime behavior remains a plain dict.

- Updated module docstring/comments to explain the intent while keeping behavior unchanged.