### PR TITLE
fix: add bounded checks and validations for conversation_history_window and also add tests

### DIFF
--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -61,7 +61,7 @@ class StandardAgent:
         self.reasoner = reasoner
 
         self.goal_preprocessor = goal_preprocessor
-        self.conversation_history_window = conversation_history_window
+        self.conversation_history_window = max(0, conversation_history_window) if conversation_history_window is not None else 5
         self.memory.setdefault("conversation_history", [])
 
         self._state: AgentState = AgentState.READY
@@ -113,5 +113,9 @@ class StandardAgent:
     def _record_interaction(self, entry: dict) -> None:
         if self.conversation_history_window <= 0:
             return
-        self.memory["conversation_history"].append(entry)
-        self.memory["conversation_history"][:] = self.memory["conversation_history"][-self.conversation_history_window:]
+
+        history = self.memory["conversation_history"]
+        history.append(entry)
+
+        if len(history) > self.conversation_history_window:
+            history[:] = history[-self.conversation_history_window:]


### PR DESCRIPTION
This PR solves the Issue: https://github.com/jentic/standard-agent/issues/86 listed for Hacktoberfest.

## Changes Made

Added the required changes in `agents/standard_agent.py`:
* Added bounds checking for `conversation_history_window` parameter to ensure negative values are converted to 0.
* Improved `_record_interaction` method to only trim history when it exceeds the window size, preventing unnecessary operations

## Tests Added

Added 2 new test cases in `tests/agents/test_standard_agent.py`:
* `test_agent_conversation_history_negative_window`: Verifies negative window values are handled correctly
* `test_agent_conversation_history_memory_bounded`: Confirms history is properly bounded with multiple interactions
