### PR TITLE
Feat/Timezone-Aware Goal Pre Processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,16 @@
 # =============================================================================
 
 # -----------------------------------------------------------------------------
+# Session Context
+# -----------------------------------------------------------------------------
+
+# Timezone for the agent session (IANA timezone identifier)
+# Examples: "America/New_York", "Europe/London", "Asia/Tokyo", "UTC"
+# Used when timezone is not explicitly provided in StandardAgent constructor
+# AGENT_TZ=America/New_York
+
+
+# -----------------------------------------------------------------------------
 # LLM PROVIDER CONFIGURATION (REQUIRED)
 # -----------------------------------------------------------------------------
 

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@
 
 # Timezone for the agent session (IANA timezone identifier)
 # Examples: "America/New_York", "Europe/London", "Asia/Tokyo", "UTC"
+# Ref links : https://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # Used when timezone is not explicitly provided in StandardAgent constructor
 # AGENT_TZ=America/New_York
 

--- a/agents/goal_preprocessor/base.py
+++ b/agents/goal_preprocessor/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Sequence, Dict, Any, Tuple
+from collections.abc import MutableMapping
 
 from agents.llm.base_llm import BaseLLM
 
@@ -11,8 +12,9 @@ class BaseGoalPreprocessor(ABC):
     Component that preprocess a raw user goal.
     """
 
-    def __init__(self, *, llm: BaseLLM):
+    def __init__(self, *, llm: BaseLLM, memory: MutableMapping | None = None):
         self.llm = llm
+        self.memory = memory
 
     @abstractmethod
     def process(self, goal: str, history: Sequence[Dict[str, Any]]) -> Tuple[str, str | None]:

--- a/agents/goal_preprocessor/conversational.py
+++ b/agents/goal_preprocessor/conversational.py
@@ -63,14 +63,15 @@ class ConversationalGoalPreprocessor(BaseGoalPreprocessor):
                 try:
                     tzinfo = ZoneInfo(tz_iana)
                     now = datetime.now(tz=tzinfo)
-                    z = now.strftime('%z')
-                    label = f"UTC{z[:3]}:{z[3:]}" if z else "UTC+00:00"
-                    return now, label
+                    return now, self._utc_offset_label(now)
                 except Exception:
                     logger.warning("invalid_timezone_string_in_memory", tz_input=tz_iana)
 
         # Fallback: use system timezone
         now = datetime.now().astimezone()
-        z = now.strftime('%z')
-        label = f"UTC{z[:3]}:{z[3:]}" if z else "UTC+00:00"
-        return now, label
+        return now, self._utc_offset_label(now)
+
+    @staticmethod
+    def _utc_offset_label(dt: datetime) -> str:
+        z = dt.strftime('%z')  # e.g. '+0530'
+        return f'UTC{z[:3]}:{z[3:]}' if z else 'UTC+00:00'

--- a/agents/prebuilt.py
+++ b/agents/prebuilt.py
@@ -112,7 +112,7 @@ class ReWOOAgentBedrock(StandardAgent):
         memory = DictMemory()
         reasoner = ReWOOReasoner(llm=llm, tools=tools, memory=memory, max_retries=max_retries)
 
-        goal_processor = ConversationalGoalPreprocessor(llm=llm)
+        goal_processor = ConversationalGoalPreprocessor(llm=llm, memory=memory)
 
         # Call parent constructor with assembled components
         super().__init__(

--- a/agents/prebuilt.py
+++ b/agents/prebuilt.py
@@ -35,7 +35,7 @@ class ReWOOAgent(StandardAgent):
         memory = DictMemory()
         reasoner = ReWOOReasoner(llm=llm, tools=tools, memory=memory, max_retries=max_retries)
 
-        goal_processor = ConversationalGoalPreprocessor(llm=llm)
+        goal_processor = ConversationalGoalPreprocessor(llm=llm, memory=memory)
 
         # Call parent constructor with assembled components
         super().__init__(
@@ -151,7 +151,7 @@ class ReACTAgentBedrock(StandardAgent):
         memory = DictMemory()
         reasoner = ReACTReasoner(llm=llm, tools=tools, memory=memory, max_turns=max_turns, top_k=top_k)
 
-        goal_processor = ConversationalGoalPreprocessor(llm=llm)
+        goal_processor = ConversationalGoalPreprocessor(llm=llm, memory=memory)
 
         # Call parent constructor with assembled components
         super().__init__(

--- a/agents/prompts/goal_preprocessors/conversational.yaml
+++ b/agents/prompts/goal_preprocessors/conversational.yaml
@@ -34,6 +34,11 @@ clarify_goal: |
   {history_str}
 
   New Goal: "{goal}"
+
+  Current Time:
+  - now_iso: {now_iso}
+  - timezone: {timezone_name}
+  - weekday: {weekday}
   </input>
 
   <output_format>
@@ -49,6 +54,7 @@ clarify_goal: |
   - If the goal is clear and actionable as-is, leave both fields as empty strings.
   - If you can resolve ambiguity using conversation history, provide only "revised_goal".
   - If you cannot resolve ambiguity, provide only "clarification_question".
+  - When the goal contains relative time references (e.g., "today", "tomorrow", "next Monday", "in 2 days"), rewrite them into absolute dates using the provided Current Time and timezone. For example, "tomorrow" → "2025-09-10".
   </output_format>
 
 

--- a/agents/prompts/goal_preprocessors/conversational.yaml
+++ b/agents/prompts/goal_preprocessors/conversational.yaml
@@ -1,32 +1,57 @@
 clarify_goal: |
   <role>
-  You are a Goal Disambiguator working within the Agent ecosystem.
-  Your responsibility is to analyze a user's new goal in the context of the recent conversation history and determine whether the goal contains critical ambiguities that prevent execution.
-  If the goal has unresolvable ambiguities, your job is to resolve them using prior context — or, if resolution is not possible, ask the user a precise follow-up question.
+  You are a **Goal Disambiguator** operating within a multi-agent system.
+  Your purpose is to determine whether a newly given user goal is *critically ambiguous* and, if so, to either:
+  - Rewrite it into an explicit, self-contained version using prior context, or
+  - Ask a single precise clarification question to the user.
+
+  You must ensure that downstream agents receive goals that are **clear, executable, and time-normalized**.
   </role>
 
   <instructions>
-  Follow these steps carefully:
+  Follow this reasoning process step by step:
 
-  1. Analyze the conversation history, prioritizing the most recent goals and results.
-  2. Identify **critical ambiguity** in the new goal — references that make the goal impossible to execute (e.g., pronouns like "it" without clear referents, phrases like "do it again" without knowing what "it" is, or unclear targets like "send it to him" without knowing what or who).
-  3. **Important**: Goals that are actionable but could be more specific are NOT ambiguous. An agent can make reasonable assumptions and proceed with execution.
-  4. If the goal contains critical ambiguity that can be resolved using conversation history, rewrite the goal to be explicit, complete, and self-contained.
-  5. If the goal contains critical ambiguity that cannot be resolved using conversation history, generate **a single clear clarification question** for the user.
-  6. If the goal is actionable (even if it could be more detailed), provide neither a revised goal nor a clarification question.
+  1. **Analyze the conversation history**:
+     - Focus on the most recent goals, clarifications, and confirmed results.
+     - Prefer the most recent references when resolving pronouns or context-dependent instructions.
 
-  Critical ambiguity signals (these make execution impossible):
-  - Pronouns without clear referents that prevent action (e.g., "send it" - what is "it"?)
-  - References to prior actions without context (e.g., "do that again" - what is "that"?)
-  - Missing essential targets (e.g., "call him back" - who is "him"?)
-  - Context-dependent tasks with no context (e.g., "fix the issue" with no prior issue mentioned)
+  2. **Identify Critical Ambiguity**:
+     - A goal is *critically ambiguous* only if it cannot be executed due to missing or unclear references.
+     - Ambiguity types include:
+       - Pronouns or demonstratives without clear referents (“it”, “that”, “those”, “do this again”)
+       - Missing essential targets (“send it to him” without knowing both “it” and “him”)
+       - Dependent references with no recoverable context (“fix the issue” without a known issue)
+       - Relative time references (“tomorrow”, “next Monday”) that need conversion to absolute ISO dates.
 
-  NOT critical ambiguity (these are actionable):
-  - General requests that can proceed with reasonable assumptions
-  - Requests missing preferences but not essential info (e.g., "book a flight to Paris" - agent can ask for dates during execution)
-  - Broad requests where agent can provide comprehensive results (e.g., "show me news about Tesla" - agent can show recent general news)
+  3. **Resolve if Possible**
+     - If ambiguity can be resolved using either:
+       a) Conversation history, and/or
+       b) The **Current Time** block (`now_iso`, `timezone`, `weekday`)
+       then rewrite the goal into a complete, standalone instruction.
+     - Replace all pronouns, relative phrases, and context-dependent words with explicit referents.
+     - **Time Normalization Precedence (MANDATORY):**
+       If the goal contains **any relative time expression** (“now”, “today”, “tomorrow”, “tonight”, “next <weekday>”, “in <n> minutes/hours/days/weeks”, “this <weekday>”), you **must** rewrite the goal to use **absolute ISO 8601** date/time computed from the provided `now_iso` in `{timezone_name}`. This rule applies even if the goal is otherwise actionable.
 
-  You must weigh recent conversation turns more heavily when resolving references.
+  4. **Ask if Unresolvable**:
+     - If the goal cannot be resolved with available context, produce a single, unambiguous clarification question.
+     - The question must be *short, specific, and directly answerable* by the user.
+
+  5. **No Action Needed**:
+     - If the goal is clear and actionable, do not modify it.
+     - Do not ask for clarification if the task can proceed with reasonable assumptions.
+
+  6. **Time Normalization**:
+     - Convert relative time expressions to absolute ISO 8601 dates.
+     - Use the provided “Current Time” section to calculate:
+       - “today” → same date as `now_iso`
+       - “tomorrow” → +1 day from `now_iso`
+       - “next Monday”, “in 3 days”, etc. → computed absolute date in `{timezone_name}`
+
+  7. **Output Rules**:
+     - Respond only with a valid JSON object.
+     - Include either `revised_goal` OR `clarification_question`, never both.
+     - If no ambiguity is found, return both as empty strings.
+
   </instructions>
 
   <input>
@@ -42,19 +67,56 @@ clarify_goal: |
   </input>
 
   <output_format>
-  Respond with a valid JSON object in the following format:
-
   {{
-    "revised_goal": string,                // If ambiguity can be resolved, return rewritten explicit goal; otherwise empty string
-    "clarification_question": string       // If ambiguity cannot be resolved, return a user-facing clarification question; otherwise empty string
+    "revised_goal": string,                // Explicit rewritten goal if ambiguity resolved; else ""
+    "clarification_question": string       // If ambiguity unresolved, one concise user-facing question; else ""
   }}
-
-  Rules:
-  - Provide EITHER a "revised_goal" OR a "clarification_question", never both.
-  - If the goal is clear and actionable as-is, leave both fields as empty strings.
-  - If you can resolve ambiguity using conversation history, provide only "revised_goal".
-  - If you cannot resolve ambiguity, provide only "clarification_question".
-  - When the goal contains relative time references (e.g., "today", "tomorrow", "next Monday", "in 2 days"), rewrite them into absolute dates using the provided Current Time and timezone. For example, "tomorrow" → "2025-09-10".
   </output_format>
 
+  <examples>
+  - Example 1:
+      Input: goal = "Send it again"
+      History: Last message was “Send the meeting invite to John.”
+      Output:
+      {{
+        "revised_goal": "Send the meeting invite to John again",
+        "clarification_question": ""
+      }}
 
+  - Example 2:
+      Input: goal = "Do that again"
+      History: No prior actions
+      Output:
+      {{
+        "revised_goal": "",
+        "clarification_question": "Could you clarify what specific action you’d like me to repeat?"
+      }}
+
+  - Example 3:
+      Input: goal = "Book a flight to Paris tomorrow"
+      Time: 2025-10-07
+      Output:
+      {{
+        "revised_goal": "Book a flight to Paris on 2025-10-08",
+        "clarification_question": ""
+      }}
+  
+  - Example 4: (relative time normalization):
+      Input goal: "Remind me tomorrow at 9"
+      Current Time: now_iso=2025-10-07T15:25:16+01:00, timezone=Europe/Dublin
+      Output:
+      {{
+        "revised_goal": "Set a reminder for 2025-10-08T09:00:00+01:00 in Europe/Dublin.",
+        "clarification_question": ""
+      }}
+  
+  - Example 5: (relative time; otherwise actionable):
+      Input goal: "What is the time now?"
+      Current Time: now_iso=2025-10-07T15:25:16+01:00, timezone=Europe/Dublin
+      Output:
+      {{
+        "revised_goal": "Report the current time as of 2025-10-07T15:25:16+01:00 in Europe/Dublin.",
+        "clarification_question": ""
+      }}
+
+  </examples>

--- a/agents/prompts/goal_preprocessors/conversational.yaml
+++ b/agents/prompts/goal_preprocessors/conversational.yaml
@@ -30,7 +30,7 @@ clarify_goal: |
        then rewrite the goal into a complete, standalone instruction.
      - Replace all pronouns, relative phrases, and context-dependent words with explicit referents.
      - **Time Normalization Precedence (MANDATORY):**
-       If the goal contains **any relative time expression** (“now”, “today”, “tomorrow”, “tonight”, “next <weekday>”, “in <n> minutes/hours/days/weeks”, “this <weekday>”), you **must** rewrite the goal to use **absolute ISO 8601** date/time computed from the provided `now_iso` in `{timezone_name}`. This rule applies even if the goal is otherwise actionable.
+       If the goal contains **any relative time expression** (“now”, “today”, “tomorrow”, “tonight”, “next <weekday>”, “in <n> minutes/hours/days/weeks”, “this <weekday>”), you **must** rewrite the goal to use the provided `now_iso` in `{timezone_name}`. This rule applies even if the goal is otherwise actionable.
 
   4. **Ask if Unresolvable**:
      - If the goal cannot be resolved with available context, produce a single, unambiguous clarification question.
@@ -41,7 +41,7 @@ clarify_goal: |
      - Do not ask for clarification if the task can proceed with reasonable assumptions.
 
   6. **Time Normalization**:
-     - Convert relative time expressions to absolute ISO 8601 dates.
+     - Convert relative time expressions to absolute ISO dates.
      - Use the provided “Current Time” section to calculate:
        - “today” → same date as `now_iso`
        - “tomorrow” → +1 day from `now_iso`

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -63,7 +63,8 @@ class StandardAgent:
             conversation_history_window: The number of past interactions to keep in memory.
 
             Session Context
-            timezone: Session timezone as IANA string like "America/New_York" https://www.iana.org/time-zones.
+            timezone: Session timezone as IANA string like "America/New_York", "Europe/London"
+            https://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
         Note:
             Session context (timezone) is stored in memory["context"] and accessible

--- a/agents/standard_agent.py
+++ b/agents/standard_agent.py
@@ -75,7 +75,6 @@ class StandardAgent:
         self.conversation_history_window = conversation_history_window
         self.memory.setdefault("conversation_history", [])
         
-        # Initialize session context in memory (store IANA timezone string or None)
         self.memory["context"] = {}
         self.memory["context"]["timezone"] = self._resolve_timezone(timezone)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "standard-agent"
-version = "0.1.9"
+version = "0.1.10"
 description = "A simple, modular library for building AI agents—with a composable core and plug‑in components."
 requires-python = ">=3.11"
 readme = "README.md"

--- a/tests/agents/goal_preprocessor/test_conversational.py
+++ b/tests/agents/goal_preprocessor/test_conversational.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, List
 
 from agents.goal_preprocessor.conversational import ConversationalGoalPreprocessor
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from tests.conftest import DummyLLM
 
@@ -32,10 +34,13 @@ def test_conversational_returns_clarification_when_present():
 
 def test_conversational_falls_back_to_original_when_empty_json():
     llm = DummyLLM(json_queue=[{}])
-    pre = ConversationalGoalPreprocessor(llm=llm)
+    tz = ZoneInfo("UTC")
+    pre = ConversationalGoalPreprocessor(llm=llm, now_fn=lambda: datetime(2025, 1, 15, 12, 0, tzinfo=tz))
 
     revised, question = pre.process("original", _history())
     assert revised == "original"
     assert question is None
+
+    # No normalization performed now; goal remains unchanged when no revision
 
 

--- a/tests/agents/goal_preprocessor/test_conversational.py
+++ b/tests/agents/goal_preprocessor/test_conversational.py
@@ -35,7 +35,7 @@ def test_conversational_returns_clarification_when_present():
 def test_conversational_falls_back_to_original_when_empty_json():
     llm = DummyLLM(json_queue=[{}])
     tz = ZoneInfo("UTC")
-    pre = ConversationalGoalPreprocessor(llm=llm, now_fn=lambda: datetime(2025, 1, 15, 12, 0, tzinfo=tz))
+    pre = ConversationalGoalPreprocessor(llm=llm)
 
     revised, question = pre.process("original", _history())
     assert revised == "original"

--- a/tests/agents/goal_preprocessor/test_conversational.py
+++ b/tests/agents/goal_preprocessor/test_conversational.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, List
+import re
 
 from agents.goal_preprocessor.conversational import ConversationalGoalPreprocessor
+from agents.memory.dict_memory import DictMemory
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -42,5 +44,108 @@ def test_conversational_falls_back_to_original_when_empty_json():
     assert question is None
 
     # No normalization performed now; goal remains unchanged when no revision
+
+
+def test_conversational_returns_utc_offset_label_when_no_iana():
+    """Test that preprocessor returns UTC offset label when no IANA in memory."""
+    llm = DummyLLM(json_queue=[{}])
+    memory = DictMemory()
+    # No timezone in context
+    pre = ConversationalGoalPreprocessor(llm=llm, memory=memory)
+    
+    now, label = pre._current_time_and_timezone()
+    
+    # Label should be in UTC offset format
+    assert label.startswith("UTC")
+    assert ":" in label  # Should have format UTC+HH:MM or UTC-HH:MM
+    # Validate format matches UTC±HH:MM
+    assert re.match(r'^UTC[+-]\d{2}:\d{2}$', label), f"Expected UTC±HH:MM format, got {label}"
+    # Time should be timezone-aware
+    assert now.tzinfo is not None
+
+
+def test_conversational_with_iana_returns_utc_offset_label():
+    """Test that preprocessor returns UTC offset label even when IANA is provided."""
+    llm = DummyLLM(json_queue=[{}])
+    memory = DictMemory()
+    memory["context"] = {"timezone": "Europe/Dublin"}  # UTC+05:30
+    pre = ConversationalGoalPreprocessor(llm=llm, memory=memory)
+    
+    now, label = pre._current_time_and_timezone()
+    
+    # Should return UTC offset label, not the IANA name
+    assert label == "UTC+01:00"
+    assert now.tzinfo is not None
+    # Verify time is computed with correct timezone
+    assert now.tzinfo.key == "Europe/Dublin"  # type: ignore
+
+
+def test_conversational_invalid_iana_falls_back(caplog):
+    """Test that invalid IANA in memory logs warning and falls back to system tz."""
+    import logging
+    llm = DummyLLM(json_queue=[{}])
+    memory = DictMemory()
+    memory["context"] = {"timezone": "Invalid/Timezone"}
+    pre = ConversationalGoalPreprocessor(llm=llm, memory=memory)
+    
+    with caplog.at_level(logging.WARNING):
+        now, label = pre._current_time_and_timezone()
+    
+    # Should fall back to system timezone and return UTC offset label
+    assert label.startswith("UTC")
+    assert re.match(r'^UTC[+-]\d{2}:\d{2}$', label)
+    assert now.tzinfo is not None
+
+
+def test_conversational_utc_offset_label_helper():
+    """Test the _utc_offset_label static method formats correctly."""
+    # UTC
+    dt_utc = datetime(2025, 1, 15, 12, 0, tzinfo=ZoneInfo("UTC"))
+    assert ConversationalGoalPreprocessor._utc_offset_label(dt_utc) == "UTC+00:00"
+    
+    # Positive offset with minutes
+    dt_kolkata = datetime(2025, 1, 15, 12, 0, tzinfo=ZoneInfo("Asia/Kolkata"))
+    assert ConversationalGoalPreprocessor._utc_offset_label(dt_kolkata) == "UTC+05:30"
+    
+    # Negative offset
+    dt_ny = datetime(2025, 1, 15, 12, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert ConversationalGoalPreprocessor._utc_offset_label(dt_ny) == "UTC-05:00"
+    
+    # DST affects offset (summer in NY is UTC-04:00)
+    dt_ny_summer = datetime(2025, 7, 15, 12, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert ConversationalGoalPreprocessor._utc_offset_label(dt_ny_summer) == "UTC-04:00"
+
+
+def test_conversational_passes_correct_timezone_info_to_prompt():
+    """Test that process() passes now_iso, timezone_name (as UTC offset), and weekday to the prompt."""
+    class CapturingLLM:
+        def __init__(self):
+            self.last_prompt = None
+        
+        def prompt_to_json(self, prompt: str, **kwargs):
+            self.last_prompt = prompt
+            return {}  # Return empty to avoid revision
+    
+    llm = CapturingLLM()
+    memory = DictMemory()
+    memory["context"] = {"timezone": "America/New_York"}
+    pre = ConversationalGoalPreprocessor(llm=llm, memory=memory)
+    
+    revised, question = pre.process("what is the time?", _history())
+    
+    # Verify prompt was called
+    assert llm.last_prompt is not None
+    
+    # Check that timezone_name is UTC offset format, not IANA
+    assert "UTC-0" in llm.last_prompt  # Either UTC-04:00 or UTC-05:00 depending on DST
+    assert "America/New_York" not in llm.last_prompt
+    
+    # Check that now_iso (ISO format datetime) is present
+    # ISO format includes 'T' and timezone offset
+    assert "T" in llm.last_prompt  # ISO datetime has T separator
+    
+    # Check that weekday is present (should be a day name)
+    weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+    assert any(day in llm.last_prompt for day in weekdays)
 
 


### PR DESCRIPTION
### The Problem
When users ask time-related questions like "what time is it?" or "schedule this for tomorrow," the agent lacks timezone context. This leads to two critical issues:
- Wrong timezone assumptions: Without explicit timezone configuration, the agent defaults to the system's local timezone (often EST/UTC), causing incorrect time interpretations for users in other regions
- No timezone injection: The goal preprocessor had no access to session timezone, so relative time expressions ("tomorrow," "next Monday") couldn't be grounded to the user's local context

### The Opportunity
- Users expect agents to understand their local time context, especially in:  
   - Multi-tenant scenarios (Slack workspaces, Discord servers) where users are in different timezones
   - Time-sensitive queries ("What's the weather tomorrow?", "Book a meeting at 3 PM")
   - Conversational ambiguity resolution ("Do it tomorrow" → which timezone's tomorrow?)

### Solution
1. **Timezone configuration**: StandardAgent can be made timezone-aware via IANA string passed to constructor or AGENT_TZ env variable. If neither is provided, defaults to system time. Stores only validated IANA strings in memory["context"]["timezone"].
2. **Unambiguous prompts**: Always emit UTC±HH:MM offset labels (e.g., UTC+05:30) for LLM prompts, never ambiguous abbreviations like "IST". Use IANA for accurate time computation (preserves DST).
3. **Goal preprocessor awareness**: Inject now_iso, timezone_name (as UTC offset), and weekday into prompts so the LLM can ground relative time expressions accurately.


**Result**: The agent now handles timezone-aware conversations correctly, eliminating ambiguity and enabling accurate time-based reasoning across multi-tenant deployments.