### PR TITLE
docs(contributing): add complete custom reasoner example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,14 +47,11 @@ from agents.tools.base import JustInTimeToolingBase
 
 
 class EchoReasoner(BaseReasoner):
-    def __init__(self, *, llm: BaseLLM, tools: JustInTimeToolingBase, memory: MutableMapping):
-        super().__init__(llm=llm, tools=tools, memory=memory)
-
     def run(self, goal: str) -> ReasoningResult:
         # Minimal run loop: ask model once, return structured result.
-        response = self.llm.invoke(f"Goal: {goal}\nProvide a concise final answer.")
+        response = self.llm.prompt(f"Goal: {goal}\nProvide a concise final answer.")
         return ReasoningResult(
-            final_answer=str(response),
+            final_answer=response,
             iterations=1,
             tool_calls=[],
             success=True,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,41 @@ Reasoner prompts are externalized in YAML under `agents/prompts/` (e.g., `agents
 
 We also encourage contributions of entirely new `BaseReasoner` implementations to explore approaches like Tree-of-Thoughts, Graph-of-Thoughts, ReAct variants, or LATS.
 
+### Example: adding a custom reasoner
+
+Below is a minimal (but complete) `BaseReasoner` implementation you can use as a starting point:
+
+```python
+from collections.abc import MutableMapping
+from agents.reasoner.base import BaseReasoner, ReasoningResult
+from agents.llm.base_llm import BaseLLM
+from agents.tools.base import JustInTimeToolingBase
+
+
+class EchoReasoner(BaseReasoner):
+    def __init__(self, *, llm: BaseLLM, tools: JustInTimeToolingBase, memory: MutableMapping):
+        super().__init__(llm=llm, tools=tools, memory=memory)
+
+    def run(self, goal: str) -> ReasoningResult:
+        # Minimal run loop: ask model once, return structured result.
+        response = self.llm.invoke(f"Goal: {goal}\nProvide a concise final answer.")
+        return ReasoningResult(
+            final_answer=str(response),
+            iterations=1,
+            tool_calls=[],
+            success=True,
+            transcript=f"Goal: {goal}\nAnswer: {response}",
+        )
+```
+
+Recommended implementation steps:
+
+1. Start from an existing reasoner (`ReWOOReasoner` or `ReACTReasoner`) and keep your first version small.
+2. Implement `run(goal: str) -> ReasoningResult` first, then add tool/memory behavior incrementally.
+3. Add prompts under `agents/prompts/reasoners/<your_reasoner>.yaml` and load via `agents/prompts/load_prompts`.
+4. Add focused tests for your reasoner behavior (success path + failure path).
+5. Document when to use your reasoner compared to existing profiles.
+
 If you have an idea to improve the Standard Agent, we'd love to see it!
 
 ## Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,7 @@ We also encourage contributions of entirely new `BaseReasoner` implementations t
 Below is a minimal (but complete) `BaseReasoner` implementation you can use as a starting point:
 
 ```python
-from collections.abc import MutableMapping
 from agents.reasoner.base import BaseReasoner, ReasoningResult
-from agents.llm.base_llm import BaseLLM
-from agents.tools.base import JustInTimeToolingBase
 
 
 class EchoReasoner(BaseReasoner):


### PR DESCRIPTION
Closes #72

## Summary
Improves `CONTRIBUTING.md` with a complete custom reasoner example and clearer implementation steps.

### What was added
- A minimal but complete `EchoReasoner` example that correctly implements `BaseReasoner` and returns `ReasoningResult`.
- A practical step-by-step checklist for contributors to add new reasoners safely.
- Prompt/test/documentation guidance aligned with the current project structure.

This aims to reduce onboarding friction for contributors implementing new reasoning profiles.
